### PR TITLE
Fix: Absolute path bug

### DIFF
--- a/docs/Understanding-Markdown-References.md
+++ b/docs/Understanding-Markdown-References.md
@@ -29,7 +29,8 @@ project's directory structure:
 
 - A reference to a Python script: [Main Python Script](src/main.py)
 - A link to a user guide Markdown file: [User Guide](docs/user_guide.md)
-- An absolute path reference: [Good Documentation](docs/good_doc.md)
+- An absolute path reference: [Good Documentation](/docs/good_doc.md)
+- An absolute path reference that is working: [Understanding-Markdown-References](/docs/Understanding-Markdown-References.md)
 
 ## Markdown Links with Headers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ flake8 = "^7.1.1"
 [tool.poetry.scripts]
 refcheck = "refcheck.main:main"
 
+[tool.poetry.scripts]
+refcheck = "refcheck.main:main"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,6 @@ flake8 = "^7.1.1"
 [tool.poetry.scripts]
 refcheck = "refcheck.main:main"
 
-[tool.poetry.scripts]
-refcheck = "refcheck.main:main"
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/refcheck/validators.py
+++ b/refcheck/validators.py
@@ -22,13 +22,81 @@ def is_valid_remote_reference(url: str) -> bool:
         return True
 
 
-def file_exists(file_path: str) -> bool:
+def file_exists(origin_file_path: str, ref_file_path: str) -> bool:
     """Check if local file exists."""
-    logger.info(f"Checking if file exists: {file_path}")
-    exists = os.path.exists(file_path)
-    if not exists:
-        logger.warning(f"File does not exist: {file_path}")
-    return exists
+    logger.info(f"Checking if file exists: {ref_file_path}")
+
+    file_exists = False
+
+    if ref_file_path.startswith("\\"):
+        # This seems to be an absolute windows path (e.g. \file.md) but it's actually a relative path to the
+        # file where the reference was made in. (I know, strange that this is valid...)
+        logger.info("Seemingly absolute reference path starts with backslash. Treating as relative path ...")
+        relative_ref = ref_file_path[1:]  # Remove leading backslash
+        logger.info(f"{ref_file_path} -> {relative_ref}")
+        if os.path.exists(relative_ref):
+            file_exists = True
+        else:
+            logger.info("File does not exist.")
+
+    elif ref_file_path.startswith("/"):
+        # This is an absolute path. We have to check if the file exists at the absolute path or as a path relative to
+        # every possible subpart of the origin file path.
+        logger.warning(f"Reference is absolute.")
+
+        # First, test the file with the absolute path
+        logger.info(f"Checking if the file exists as an absolute path ...")
+        abs_ref_path = os.path.abspath(ref_file_path)
+        logger.info(f"-> '{abs_ref_path}'")
+        if os.path.exists(abs_ref_path):
+            file_exists = True
+        else:
+            logger.info(f"File does not exist as an absolute path.")
+            # Strip the leading slash to convert the path to a relative path
+            ref = ref_file_path[1:]
+
+            # Get the absolute path of the file where the reference was made in, e.g., C:/Users/user/repo/docs/file.md
+            absolute_file_path = os.path.abspath(origin_file_path)
+
+            # Check if the file exists relative to the file in which the reference was made in
+            logger.info(f"Checking if the path exists relative to the file in which the reference was made in ...")
+            abs_ref_path = os.path.join(os.path.dirname(absolute_file_path), ref)
+            logger.info(f"-> '{abs_ref_path}'.")
+
+            if os.path.exists(abs_ref_path):
+                file_exists = True
+            else:
+                # Traverse up the directory tree and test the relative path for each directory until we either
+                # find the file, or cannot go up any further.
+                logger.info("File does not exists there. Moving up the directory tree to find the file ...")
+
+                starting_dir = os.path.dirname(absolute_file_path)
+                while True:
+                    parent_dir = os.path.dirname(starting_dir)
+                    abs_ref_path = os.path.join(parent_dir, ref)
+                    logger.info(f"-> {abs_ref_path}")
+                    if os.path.exists(abs_ref_path):
+                        file_exists = True
+                        break
+                    else:
+                        logger.info("File does not exist. Moving up the directory tree ...")
+                        if parent_dir == starting_dir:
+                            logger.info("Reached the root of the repository. Stopping search.")
+                            break
+
+                        starting_dir = parent_dir
+    else:
+        # It is a simple relative path. Check if the file exists relative to the file in which the reference was made in.
+        ref_file_path = os.path.join(os.path.dirname(origin_file_path), ref_file_path)
+        if os.path.exists(ref_file_path):
+            file_exists = True
+
+    if file_exists:
+        logger.info("File exists!")
+        return True
+    else:
+        logger.info("File does not exist.")
+        return False
 
 
 def header_exists(file_path: str, header: str) -> bool:
@@ -69,16 +137,14 @@ def is_valid_markdown_reference(ref: str, file_path: str) -> bool:
     elif "#" in ref:
         logger.info("Reference is a header in another Markdown file.")
         referenced_file, referenced_header = ref.split("#", 1)
-        target_path = os.path.join(base_path, referenced_file)
+        target_path = referenced_file
     else:
-        logger.info("Reference is to another Markdown file.")
         referenced_file = ref
         referenced_header = None
-        target_path = os.path.join(base_path, referenced_file)
+        target_path = referenced_file
 
     # Check if the referenced file exists
-    if not file_exists(target_path):
-        logger.error(f"Referenced file does not exist: {target_path}")
+    if not file_exists(file_path, target_path):
         return False
 
     # Check if the referenced header exists

--- a/tests/sample_markdown.md
+++ b/tests/sample_markdown.md
@@ -46,6 +46,7 @@ Here is a footnote reference[^1].
 - [Installation Instructions](other-directory/README.md#installation-instructions)
 - [Getting Started](/path/to/README.md#getting-started)
 - [Reference to a header in the same file](#file-links)
+- [Reference with absolute path using backslash](\test_parsers.py)
 
 # HTML Images
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -70,6 +70,7 @@ def test_file_links(sample_markdown):
         ("other-directory/README.md#installation-instructions", 46),
         ("/path/to/README.md#getting-started", 47),
         ("#file-links", 48),
+        ("\\test_parsers.py", 49),
     ]
     assert file_refs == expected
 
@@ -77,7 +78,7 @@ def test_file_links(sample_markdown):
 # Tests for HTML images
 def test_html_images(sample_markdown):
     html_images = _find_matches_with_line_numbers(HTML_IMAGE_PATTERN, sample_markdown, group=2)
-    expected = [("https://www.openai.com/logo.png", 52), ("/assets/img.png", 53), ("image.png", 54)]
+    expected = [("https://www.openai.com/logo.png", 53), ("/assets/img.png", 54), ("image.png", 55)]
     assert html_images == expected
 
 
@@ -165,6 +166,10 @@ def test_invalid_arg_parser():
             {"file_refs": [("/project/docs/good-doc.md#introduction", 1)]},
         ),
         ("- [Reference to a header in the same file](#getting-started)", {"file_refs": [("#getting-started", 1)]}),
+        (
+            "- [Absolute reference using backslash](\\path\\to\\README.md#getting-started)",
+            {"file_refs": [("\\path\\to\\README.md#getting-started", 1)]},
+        ),
         (
             '- <img src="https://www.openai.com/logo.png" alt="OpenAI Logo">',
             {"html_images": [("https://www.openai.com/logo.png", 1)]},

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,7 +2,6 @@ import pytest
 from unittest.mock import patch, mock_open
 from refcheck.validators import (
     is_valid_remote_reference,
-    file_exists,
     header_exists,
     normalize_header,
     is_valid_markdown_reference,
@@ -22,17 +21,6 @@ def test_is_valid_remote_reference(mock_requests_head):
     # Mock exception
     mock_requests_head.side_effect = Exception()
     assert not is_valid_remote_reference("https://example.com")
-
-
-@patch("os.path.exists")
-def test_file_exists(mock_path_exists):
-    # Mock file exists
-    mock_path_exists.return_value = True
-    assert file_exists("/project/docs/user_guide.md")
-
-    # Mock file does not exist
-    mock_path_exists.return_value = False
-    assert not file_exists("/project/docs/user_guide.md")
 
 
 def test_normalize_header():

--- a/tests/test_validators/test_file_exists.py
+++ b/tests/test_validators/test_file_exists.py
@@ -1,0 +1,201 @@
+import os
+from unittest import mock
+import pytest
+
+from refcheck.validators import file_exists
+
+
+@pytest.fixture
+def mock_os_path_exists():
+    with mock.patch("os.path.exists") as mock_exists:
+        yield mock_exists
+
+
+@pytest.fixture
+def mock_os_path_abspath():
+    with mock.patch("os.path.abspath") as mock_abspath:
+        yield mock_abspath
+
+
+# === Test cases for relative paths ===
+
+
+def test_file_exists_simple_relative_path(mock_os_path_exists):
+    mock_os_path_exists.return_value = True
+    result = file_exists("some/path/origin.md", "relative_file.md")
+    assert result is True
+    mock_os_path_exists.assert_called_once_with(os.path.join("some/path", "relative_file.md"))
+
+
+def test_file_does_not_exist_simple_relative_path(mock_os_path_exists):
+    mock_os_path_exists.return_value = False
+    result = file_exists("some/path/origin.md", "relative_file.md")
+    assert result is False
+    mock_os_path_exists.assert_called_once_with(os.path.join("some/path", "relative_file.md"))
+
+
+def test_file_exists_relative_path_in_subdirectory(mock_os_path_exists):
+    mock_os_path_exists.side_effect = lambda path: path in [os.path.join("some/path", "subdir/relative_file.md")]
+    result = file_exists("some/path/origin.md", "subdir/relative_file.md")
+    assert result is True
+    mock_os_path_exists.assert_called_once_with(os.path.join("some/path", "subdir/relative_file.md"))
+
+
+def test_file_does_not_exist_relative_path_in_subdirectory(mock_os_path_exists):
+    mock_os_path_exists.side_effect = lambda path: False
+
+    result = file_exists("some/path/origin.md", "subdir/relative_file.md")
+
+    assert result is False
+    assert mock_os_path_exists.call_count >= 1
+
+
+# === Absolute Windows paths ===
+
+
+def test_file_exists_absolute_windows_path(mock_os_path_exists):
+    mock_os_path_exists.side_effect = lambda path: path == "relative_file.md"
+    result = file_exists("some/path/origin.md", r"\relative_file.md")
+    assert result is True
+    mock_os_path_exists.assert_called_once_with("relative_file.md")
+
+
+def test_file_does_not_exist_absolute_windows_path(mock_os_path_exists):
+    mock_os_path_exists.side_effect = lambda path: False
+    result = file_exists("some/path/origin.md", r"\relative_file.md")
+    assert result is False
+    mock_os_path_exists.assert_called_once_with("relative_file.md")
+
+
+# === Absolute paths ===
+
+
+def test_file_exists_absolute_path(mock_os_path_exists, mock_os_path_abspath):
+    mock_os_path_exists.side_effect = lambda path: path in [
+        "/absolute/path/file.md",
+        "/absolute/path/relative_file.md",
+    ]
+    mock_os_path_abspath.return_value = "/absolute/path/file.md"
+
+    result = file_exists("/origin/path/origin.md", "/relative_file.md")
+
+    assert result is True
+    assert mock_os_path_abspath.call_count >= 1
+    assert mock_os_path_exists.call_count >= 1
+
+
+def test_file_does_not_exist_absolute_path(mock_os_path_exists, mock_os_path_abspath):
+    mock_os_path_exists.return_value = False
+    mock_os_path_abspath.return_value = "/absolute/path/file.md"
+
+    result = file_exists("some/path/origin.md", "/relative_file.md")
+
+    assert result is False
+    assert mock_os_path_abspath.call_count >= 1
+    assert mock_os_path_exists.call_count >= 1
+
+
+def test_file_exists_absolute_path_in_subdirectory(mock_os_path_exists, mock_os_path_abspath):
+    # Test if the function can correctly identify an absolute reference path that is actually relative to the file where
+    # the reference was made in.
+    #
+    # Example:
+    # - Folder structure:
+    #   -> C:/Users/user/repo/file.md
+    #   -> C:/Users/user/repo/docs/other_file.md
+    # - Input:
+    #   -> Origin file: `C:/Users/user/repo/file.md`
+    #   -> Reference: `/docs/other_file.md`
+    #
+    # The reference path `/docs/other_file.md` seems to be an absolute path, but it is actually a relative path to the root
+    # of `repo` in which the `file.md` is located. This is valid reference syntax. Therefore, the function should check if
+    # the file exists at the following locations:
+    #   1. `C:/docs/other_file.md` (Absolute path)
+    #   2. `C:/Users/user/repo/docs/other_file.md`
+
+    mock_os_path_exists.side_effect = lambda path: path in [
+        "/absolute/path/file.md",
+        "/absolute/path/subdir/relative_file.md",
+        "/origin/path/subdir/relative_file.md",
+        "/subdir/relative_file.md",
+    ]
+
+    mock_os_path_abspath.side_effect = lambda path: {
+        "/origin/path/subdir/relative_file.md": "/absolute/path/subdir/relative_file.md",
+        "/origin/path/origin.md": "/absolute/path/file.md",
+    }.get(path, path)
+
+    result = file_exists("/origin/path/origin.md", "/subdir/relative_file.md")
+
+    assert result is True
+    assert mock_os_path_abspath.call_count >= 1
+    assert mock_os_path_exists.call_count >= 1
+
+
+def test_file_exists_traverse_up_directory_tree(mock_os_path_exists, mock_os_path_abspath):
+    # Test if the function can correctly traverse up the directory tree to find the referenced file that is relative to
+    # the root of the directories where the `origin.md` is located.
+    #
+    # Example:
+    # /absolute/path/
+    # ├── file.md
+    # ├── relative_file.md
+    # └── subdir/
+    #     └── origin.md
+    #
+    # - Input:
+    #   -> Origin file: `/origin/path/subdir/origin.md`
+    #   -> Reference path: `/relative_file.md`
+    #
+    # If the `file_exists()` function works as intened it should proceed like this:
+    # - The reference path `/relative_file.md` is treated as an absolute path initially.
+    # - If not found as an absolute path, it treats it as a path related to the directories above the origin file.
+    # Therefore, the function should check if the file exists at the following locations:
+    #   1. `/relative_file.md` (Absolute path)
+    #   2. `/absolute/path/relative_file.md` (Relative path traversing up the tree from `/absolute/path/subdir/origin.md`)
+    #
+    # The expected behavior is to successfully find the `relative_file.md` file while traversing up the tree.
+
+    mock_os_path_exists.side_effect = lambda path: path in [
+        "/absolute/path/file.md",  # Simulating that this file exists
+        "/absolute/path/relative_file.md",  # Simulating that this file exists as a relative path in the parent directory
+    ]
+
+    mock_os_path_abspath.return_value = "/absolute/path/file.md"  # Mocking the absolute path of the origin file
+
+    # Calling the file_exists function with:
+    # - An origin file path of `/origin/path/subdir/origin.md`
+    # - A reference path of `/relative_file.md`
+    result = file_exists("/origin/path/subdir/origin.md", "/relative_file.md")
+
+    # Asserting that the result is True, indicating that the file was found
+    assert result is True
+
+    # Asserting that os.path.abspath was called at least once
+    # This ensures that the function attempts to convert the path to absolute at some point
+    assert mock_os_path_abspath.call_count >= 1
+
+    # Asserting that os.path.exists was called at least once
+    # This checks if the function actually checked for file existence
+    assert mock_os_path_exists.call_count >= 1
+
+
+# === Edge cases such as invalid paths or unusual formats ===
+
+
+def test_file_invalid_path(mock_os_path_exists):
+    mock_os_path_exists.return_value = False
+
+    result = file_exists("some/path/origin.md", "invalid_path.json?query=string")
+
+    assert result is False
+    mock_os_path_exists.assert_called_once()
+
+
+def test_file_valid_path_with_query_string(mock_os_path_exists):
+    mock_os_path_exists.return_value = True
+
+    result = file_exists("some/path/origin.md", "valid_path.md?query=string")
+
+    assert result is True
+    mock_os_path_exists.assert_called_once()


### PR DESCRIPTION
References can look like this: [sometext](/docs/test.md).

Problem: The reference /docs/test.md isn't actually an absolute reference, but a reference related to some other parent folder that is being used as a root folder.

Therefore, references with this syntax have to be tested twice:

The existence of the file as is, which means as an absolute file path The existence of the file related to some parent directory. To solve 2., you would have to take the absolute path of the file where this reference was made in and traverse it upwards, testing in each upwards movement step, if the file exists relative to that path.

---------