### PR TITLE
feat(stdout): Beautify tool output

### DIFF
--- a/refcheck/main.py
+++ b/refcheck/main.py
@@ -10,8 +10,6 @@ from refcheck.parsers import MarkdownParser, Reference
 from refcheck.validators import file_exists, is_valid_markdown_reference
 from refcheck.utils import (
     get_markdown_files_from_args,
-    print_green_background,
-    print_red_background,
     print_red,
     print_green,
     print_yellow,

--- a/refcheck/main.py
+++ b/refcheck/main.py
@@ -26,8 +26,7 @@ class BrokenReference(Reference):
 
 
 class ReferenceChecker:
-    def __init__(self, no_color: bool):
-        self.no_color = no_color
+    def __init__(self):
         self.broken_references: List[BrokenReference] = []
 
     def check_references(self, references: list[Reference]):
@@ -77,7 +76,10 @@ class ReferenceChecker:
             for broken_ref in self.broken_references:
                 print(f"{broken_ref.file_path}:{broken_ref.line_number}: {broken_ref.syntax}")
         else:
-            print(print_green("\U0001F389 No broken references."))
+            if settings.no_color:
+                print("No broken references!")
+            else:
+                print(print_green("\U0001F389 No broken references!"))
 
         print("====================================================================")
 
@@ -105,7 +107,7 @@ def main() -> bool:
         print(f"- {file}")
 
     md_parser = MarkdownParser()
-    checker = ReferenceChecker(settings.no_color)
+    checker = ReferenceChecker()
 
     for file in markdown_files:
         print(f"\n[+] FILE: {file}")

--- a/refcheck/main.py
+++ b/refcheck/main.py
@@ -69,8 +69,6 @@ class ReferenceChecker:
     def print_summary(self):
         print("\nReference check complete.")
         print("\n============================| Summary |=============================")
-        print(print_green("[+] "))
-
 
         if self.broken_references:
             print(print_red(f"[!] {len(self.broken_references)} broken references found:"))

--- a/refcheck/main.py
+++ b/refcheck/main.py
@@ -42,27 +42,27 @@ class ReferenceChecker:
                 try:
                     response = requests.head(ref.link, timeout=5, verify=False)
                     if response.status_code < 400:
-                        status = print_green_background("OK")
+                        status = print_green("OK")
                     else:
                         logger.info(f"Status code: {response.status_code}, Reason: {response.reason}")
-                        status = print_red_background("BROKEN")
+                        status = print_red("BROKEN")
                         self.broken_references.append(BrokenReference(**ref.__dict__, status=status))
                 except requests.exceptions.RequestException as e:
                     logger.error(f"Error: Could not reach remote reference '{ref.link}': {e}")
-                    status = print_red_background("BROKEN")
+                    status = print_red("BROKEN")
                     self.broken_references.append(BrokenReference(**ref.__dict__, status=status))
             else:
                 if ".md" in ref.link or "#" in ref.link:
                     if is_valid_markdown_reference(ref):
-                        status = print_green_background("OK")
+                        status = print_green("OK")
                     else:
-                        status = print_red_background("BROKEN")
+                        status = print_red("BROKEN")
                         self.broken_references.append(BrokenReference(**ref.__dict__, status=status))
                 else:
                     if file_exists(ref.file_path, ref.link):
-                        status = print_green_background("OK")
+                        status = print_green("OK")
                     else:
-                        status = print_red_background("BROKEN")
+                        status = print_red("BROKEN")
                         self.broken_references.append(BrokenReference(**ref.__dict__, status=status))
             print(f"{ref.file_path}:{ref.line_number}: {ref.syntax} - {status}")
 
@@ -118,6 +118,9 @@ def main() -> bool:
         image_refs = references["basic_images"]
         logging.info(f"Checking {len(image_refs)} image references ...")
         checker.check_references(image_refs)
+
+        if len(basic_refs) == 0 and len(image_refs) == 0:
+            print("No references found.")
 
         # TODO: activate when pre-processing is implemented in parsers
         # inline_links = references["inline_links"]

--- a/refcheck/main.py
+++ b/refcheck/main.py
@@ -14,6 +14,7 @@ from refcheck.utils import (
     print_red_background,
     print_red,
     print_green,
+    print_yellow,
 )
 
 logger = logging.getLogger()
@@ -31,52 +32,54 @@ class ReferenceChecker:
 
     def check_references(self, references: list[Reference]):
         for ref in references:
-            logger.info(f"REFERENCE: {ref.__dict__}")
+            logger.info(ref)
 
             if ref.is_remote and not settings.check_remote:
                 logger.warning("Skipping remote reference check.")
-                continue
+                status = print_yellow("SKIPPED")
             elif ref.is_remote and settings.check_remote:
                 # Check if remote reference is reachable
                 try:
                     response = requests.head(ref.link, timeout=5, verify=False)
                     if response.status_code < 400:
-                        status = print_green_background("OK", self.no_color)
+                        status = print_green_background("OK")
                     else:
                         logger.info(f"Status code: {response.status_code}, Reason: {response.reason}")
-                        status = print_red_background("BROKEN", self.no_color)
+                        status = print_red_background("BROKEN")
                         self.broken_references.append(BrokenReference(**ref.__dict__, status=status))
                 except requests.exceptions.RequestException as e:
                     logger.error(f"Error: Could not reach remote reference '{ref.link}': {e}")
-                    status = print_red_background("BROKEN", self.no_color)
+                    status = print_red_background("BROKEN")
                     self.broken_references.append(BrokenReference(**ref.__dict__, status=status))
             else:
                 if ".md" in ref.link or "#" in ref.link:
                     if is_valid_markdown_reference(ref):
-                        status = print_green_background("OK", self.no_color)
+                        status = print_green_background("OK")
                     else:
-                        status = print_red_background("BROKEN", self.no_color)
+                        status = print_red_background("BROKEN")
                         self.broken_references.append(BrokenReference(**ref.__dict__, status=status))
                 else:
                     if file_exists(ref.file_path, ref.link):
-                        status = print_green_background("OK", self.no_color)
+                        status = print_green_background("OK")
                     else:
-                        status = print_red_background("BROKEN", self.no_color)
+                        status = print_red_background("BROKEN")
                         self.broken_references.append(BrokenReference(**ref.__dict__, status=status))
             print(f"{ref.file_path}:{ref.line_number}: {ref.syntax} - {status}")
 
     def print_summary(self):
         print("\nReference check complete.")
         print("\n============================| Summary |=============================")
+        print(print_green("[+] "))
+
 
         if self.broken_references:
-            print(print_red(f"[!] {len(self.broken_references)} broken references found:", self.no_color))
+            print(print_red(f"[!] {len(self.broken_references)} broken references found:"))
             self.broken_references = sorted(self.broken_references, key=lambda ref: (ref.file_path, ref.line_number))
 
             for broken_ref in self.broken_references:
                 print(f"{broken_ref.file_path}:{broken_ref.line_number}: {broken_ref.syntax}")
         else:
-            print(print_green("\U0001F389 No broken references.", self.no_color))
+            print(print_green("\U0001F389 No broken references."))
 
         print("====================================================================")
 
@@ -91,12 +94,12 @@ def main() -> bool:
 
     check_remote: bool = settings.check_remote
     if not check_remote:
-        print("[!] WARNING: Skipping remote reference check. Enable with arg --check-remote.")
+        print(print_yellow("[!] WARNING: Skipping remote reference check. Enable with arg --check-remote."))
 
     # Retrieve all markdown files specified by the user
     markdown_files = get_markdown_files_from_args(settings.paths, settings.exclude)
     if not markdown_files:
-        print("[!] No Markdown files specified or found.")
+        print(print_red("[!] No Markdown files specified or found."))
         return False
 
     print(f"\n[+] {len(markdown_files)} Markdown files to check.")

--- a/refcheck/utils.py
+++ b/refcheck/utils.py
@@ -1,6 +1,8 @@
 import os
 import logging
 
+from refcheck.settings import settings
+
 logger = logging.getLogger()
 
 IGNORE_FILE = ".refcheckignore"
@@ -27,7 +29,7 @@ def load_exclusion_patterns() -> list:
         with open(IGNORE_FILE, "r", encoding="utf-8") as file:
             exclusions = [line.strip() for line in file if line.strip()]
 
-    print(f"[!] WARNING: Will skip these files and directories: {exclusions}")
+    print(print_yellow(f"[!] WARNING: Skipping these files and directories: {exclusions}"))
     return exclusions
 
 
@@ -75,17 +77,21 @@ def get_markdown_files_from_args(paths: list[str], exclude: list[str] = []) -> l
     return list(markdown_files)
 
 
-def print_green_background(text: str, no_color: bool = False) -> str:
-    return text if no_color else f"\033[42m{text}\033[0m"
+def print_green_background(text: str) -> str:
+    return text if settings.no_color else f"\033[42m{text}\033[0m"
 
 
-def print_red_background(text: str, no_color: bool = False) -> str:
-    return text if no_color else f"\033[41m{text}\033[0m"
+def print_red_background(text: str) -> str:
+    return text if settings.no_color else f"\033[41m{text}\033[0m"
 
 
-def print_red(text: str, no_color: bool = False) -> str:
-    return text if no_color else f"\033[31m{text}\033[0m"
+def print_red(text: str) -> str:
+    return text if settings.no_color else f"\033[31m{text}\033[0m"
 
 
-def print_green(text: str, no_color: bool = False) -> str:
-    return text if no_color else f"\033[32m{text}\033[0m"
+def print_green(text: str) -> str:
+    return text if settings.no_color else f"\033[32m{text}\033[0m"
+
+
+def print_yellow(text: str) -> str:
+    return text if settings.no_color else f"\033[33m{text}\033[0m"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from refcheck.utils import (
     print_red_background,
     print_red,
     print_green,
+    print_yellow
 )
 
 
@@ -114,36 +115,67 @@ def test_get_markdown_files_from_args(paths, exclude, expected_files, expected_w
 
 # === Test print functions ===
 
+@pytest.fixture
+def mock_settings_no_color_true():
+    with patch('refcheck.utils.settings') as mock_settings:
+        mock_settings.no_color = True
+        yield mock_settings
 
-def test_print_green_background():
-    result = print_green_background("Test", no_color=False)
-    expected = "\033[42mTest\033[0m"
-    assert result == expected
+@pytest.fixture
+def mock_settings_no_color_false():
+    with patch('refcheck.utils.settings') as mock_settings:
+        mock_settings.no_color = False
+        yield mock_settings
 
+# Green background
 
-def test_print_red_background():
-    result = print_red_background("Test", no_color=False)
-    expected = "\033[41mTest\033[0m"
-    assert result == expected
+def test_print_green_background_no_color(mock_settings_no_color_true):
+    result = print_green_background("test")
+    assert result == "test"
 
+def test_print_green_background_color(mock_settings_no_color_false):
+    result = print_green_background("test")
+    assert result == "\033[42mtest\033[0m"
 
-def test_print_red():
-    result = print_red("Test", no_color=False)
-    expected = "\033[31mTest\033[0m"
-    assert result == expected
+# Red background
 
+def test_print_red_background_no_color(mock_settings_no_color_true):
+    result = print_red_background("test")
+    assert result == "test"
 
-def test_print_green():
-    result = print_green("Test", no_color=False)
-    expected = "\033[32mTest\033[0m"
-    assert result == expected
+def test_print_red_background_color(mock_settings_no_color_false):
+    result = print_red_background("test")
+    assert result == "\033[41mtest\033[0m"
 
+# Red
 
-def test_print_with_no_color():
-    assert print_green_background("Test", no_color=True) == "Test"
-    assert print_red_background("Test", no_color=True) == "Test"
-    assert print_red("Test", no_color=True) == "Test"
-    assert print_green("Test", no_color=True) == "Test"
+def test_print_red_no_color(mock_settings_no_color_true):
+    result = print_red("test")
+    assert result == "test"
+
+def test_print_red_color(mock_settings_no_color_false):
+    result = print_red("test")
+    assert result == "\033[31mtest\033[0m"
+
+# Green
+
+def test_print_green_no_color(mock_settings_no_color_true):
+    result = print_green("test")
+    assert result == "test"
+
+def test_print_green_color(mock_settings_no_color_false):
+    result = print_green("test")
+    assert result == "\033[32mtest\033[0m"
+
+# Yellow
+
+def test_print_yellow_no_color(mock_settings_no_color_true):
+    result = print_yellow("test")
+    assert result == "test"
+
+def test_print_yellow_color(mock_settings_no_color_false):
+    result = print_yellow("test")
+    assert result == "\033[33mtest\033[0m"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- replace background color for flagging references `BROKEN` or `OK` with normal color to make it look a bit calmer
- also add skipped references to stdout with a flag `SKIPPED` and color yellow
- add colored output for configuration warnings like "remote check will be skipped"
- add print statement to a checked markdown file saying `No references found.` if there were no references to check, so you don't get the impression something went wrong for that file.
- improve print output a bit in general