### PR TITLE
fix: exclude bare emails from broken reference detection (#108)

### DIFF
--- a/.github/workflows/version-preview.yml
+++ b/.github/workflows/version-preview.yml
@@ -21,9 +21,6 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install python-semantic-release
-        run: pip install "python-semantic-release<8"
-
       - name: Get current version
         id: current
         run: |
@@ -33,34 +30,48 @@ jobs:
       - name: Preview next version
         id: preview
         run: |
-          # Get the next version using semantic-release
-          semantic-release version --print > version_output.txt 2>&1 || true
-          cat version_output.txt
+          CURRENT="${{ steps.current.outputs.version }}"
 
-          # Check if a new version would be released
-          if grep -q "The next version is:" version_output.txt; then
-            NEXT=$(grep "The next version is:" version_output.txt | sed 's/.*The next version is: //')
+          # Analyze PR commit messages to determine version bump type.
+          # In a PR checkout, origin/main..HEAD contains the PR commits.
+          COMMITS=$(git log --format="%s" origin/main..HEAD 2>/dev/null || true)
+
+          BUMP_TYPE=""
+          while IFS= read -r msg; do
+            [ -z "$msg" ] && continue
+
+            # Check for breaking change indicator
+            if echo "$msg" | grep -qE '^[a-z]+(\(.+\))?!:'; then
+              BUMP_TYPE="major"
+              break
+            fi
+
+            # Check commit type prefix
+            TYPE=$(echo "$msg" | sed -n 's/^\([a-z]*\)\(([^)]*)\)\?:.*/\1/p')
+            case "$TYPE" in
+              feat)
+                [ "$BUMP_TYPE" != "major" ] && BUMP_TYPE="minor"
+                ;;
+              fix|perf)
+                [ -z "$BUMP_TYPE" ] && BUMP_TYPE="patch"
+                ;;
+            esac
+          done <<< "$COMMITS"
+
+          if [ -n "$BUMP_TYPE" ]; then
+            # Calculate next version
+            MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+            MINOR=$(echo "$CURRENT" | cut -d. -f2)
+            PATCH=$(echo "$CURRENT" | cut -d. -f3)
+
+            case "$BUMP_TYPE" in
+              major) NEXT="$((MAJOR + 1)).0.0" ;;
+              minor) NEXT="$MAJOR.$((MINOR + 1)).0" ;;
+              patch) NEXT="$MAJOR.$MINOR.$((PATCH + 1))" ;;
+            esac
+
             echo "next_version=$NEXT" >> $GITHUB_OUTPUT
             echo "will_bump=true" >> $GITHUB_OUTPUT
-            
-            # Determine bump type by comparing versions
-            CURRENT="${{ steps.current.outputs.version }}"
-            CURRENT_MAJOR=$(echo $CURRENT | cut -d. -f1)
-            CURRENT_MINOR=$(echo $CURRENT | cut -d. -f2)
-            CURRENT_PATCH=$(echo $CURRENT | cut -d. -f3)
-            
-            NEXT_MAJOR=$(echo $NEXT | cut -d. -f1)
-            NEXT_MINOR=$(echo $NEXT | cut -d. -f2)
-            NEXT_PATCH=$(echo $NEXT | cut -d. -f3)
-            
-            if [ "$NEXT_MAJOR" -gt "$CURRENT_MAJOR" ]; then
-              BUMP_TYPE="major"
-            elif [ "$NEXT_MINOR" -gt "$CURRENT_MINOR" ]; then
-              BUMP_TYPE="minor"
-            else
-              BUMP_TYPE="patch"
-            fi
-            
             echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
           else
             echo "will_bump=false" >> $GITHUB_OUTPUT

--- a/poetry.lock
+++ b/poetry.lock
@@ -513,18 +513,18 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.15"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 groups = ["main", "dev"]
 files = [
-    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
-    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
+    {file = "idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"},
+    {file = "idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"},
 ]
 
 [package.extras]
-all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "importlib-metadata"
@@ -1122,21 +1122,21 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1491,14 +1491,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]
@@ -1668,4 +1668,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "30d63f7f9192345dcfe996723efd5b57ddc3fde78b2ca6ba71300988ebb40609"
+content-hash = "a54d60143d45abc0dc4956702c6ff6d2d80eda3b96061c21e46c762173c6b23a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ python = "^3.10"
 requests = "^2.32.3"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.3.4"
+pytest = ">=8.3.4,<10.0.0"
 pytest-cov = "^6.0.0"
 commitizen = "^4.2.2"
 python-semantic-release = ">=9.20,<11.0"

--- a/refcheck/parsers.py
+++ b/refcheck/parsers.py
@@ -14,7 +14,7 @@ BASIC_REFERENCE_PATTERN = re.compile(r"!*\[(?P<text>[^\]]+)\]\((?P<link>[^)]+)\)
 BASIC_IMAGE_PATTERN = re.compile(r"!\[(?P<text>[^(){}\[\]]+)\]\((?P<link>[^(){}\[\]]+)\)")  # ![]()
 
 # Inline Links - <http://example.com>
-INLINE_LINK_PATTERN = re.compile(r"<(?P<link>(?:https?://|mailto:|[a-zA-Z0-9._%+-]+@)[^>]+)>")
+INLINE_LINK_PATTERN = re.compile(r"<(?P<link>(?:https?://|mailto:)[^>]+)>")
 
 RAW_LINK_PATTERN = re.compile(
     r"(^| )(?:(https?://\S+))"

--- a/tests/fixtures/valid/inline_links.md
+++ b/tests/fixtures/valid/inline_links.md
@@ -10,9 +10,9 @@ HTTP link: <http://example.org>
 
 ## Email Links
 
-Contact: <user@example.com>
+Explicit mailto: <mailto:support@example.com>
 
-Support: <mailto:support@example.com>
+Bare emails like <user@example.com> are valid Markdown but not validated as references.
 
 ## Mixed Content
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -53,9 +53,24 @@ Email: <user@example.com>
         result = parser.parse_markdown_file(file_path)
 
         inline_links = result["inline_links"]
-        assert len(inline_links) == 2
+        assert len(inline_links) == 1
         assert inline_links[0].link == "https://example.com"
-        assert inline_links[1].link == "user@example.com"
+
+    def test_parse_markdown_file_inline_links_ignores_bare_emails(self, temp_markdown_file):
+        """Test that bare emails in angle brackets are not matched as inline links."""
+        content = """# Test
+Contact <user@example.com> for help.
+Or use <mailto:user@example.com> instead.
+Visit <https://example.com> for more.
+"""
+        file_path = temp_markdown_file(content)
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(file_path)
+
+        inline_links = result["inline_links"]
+        assert len(inline_links) == 2
+        assert inline_links[0].link == "mailto:user@example.com"
+        assert inline_links[1].link == "https://example.com"
 
     def test_parse_markdown_file_code_block_filtering(self, temp_markdown_file):
         """Test that references inside code blocks are ignored."""


### PR DESCRIPTION
## Summary

Merge the fix from #109 (which was accidentally merged into `dev` instead of `main`) into `main` to trigger the release.

Bare email addresses in angle brackets (e.g., `<user@example.com>`) were incorrectly flagged as broken references. This removes the email-matching alternative from the `INLINE_LINK_PATTERN` regex so only URLs (`http://`, `https://`) and explicit `mailto:` links are matched.

Closes #108

### Type of change

- [x] Bug fix

## Changes

- Remove the `[a-zA-Z0-9._%+-]+@` alternative from `INLINE_LINK_PATTERN` in `parsers.py`
- Update tests and fixtures for email filtering
- Fix version preview workflow to analyze PR commits directly

## How to test

See #109