### PR TITLE
feat: add inline ignore comments for line/section skipping (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![CI/CD](https://github.com/flumi3/markdown-refcheck/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/flumi3/markdown-refcheck/actions/workflows/ci-cd.yml)
 
 Markdown RefCheck is a simple tool that checks Markdown references to find any broken links.  
-It helps keeping your documentation free from broken section refs, missing images and files, and unavailable websites links.
+It helps keeping your documentation free from broken section refs, missing images and files, and unavailable websites
+links.
 
 ```text
 usage: refcheck [OPTIONS] [PATH ...]
@@ -27,57 +28,14 @@ options:
 
 ## Features
 
-- 🔍 **Reference Detection** - Find and validate various reference patterns in Markdown files
+- 🔍 **Reference Detection** - Validate various reference patterns in Markdown files
 - ❌ **Broken Link Highlighting** - Quickly identify broken references with clear error messages
 - 🌐 **Remote URL Checking** - Validate external HTTP/HTTPS links (optional with `--check-remote`)
 - 🛠️ **User-Friendly CLI** - Simple and intuitive command-line interface
 - 🎨 **Colored Output** - Clear, color-coded results for easy scanning (disable with `--no-color`)
 - ⚙️ **CI/CD Ready** - Perfect for automated quality checks in your documentation workflows
-- 🚀 **Pre-commit Integration** - Available as a pre-commit hook for automated validation
-- 💬 **Inline Ignore Comments** - Suppress false positives with `<!-- refcheck-ignore -->` directives
-
-## Ignoring References
-
-Use HTML comment directives to suppress false positives on specific lines or sections.
-
-### Skip a single line
-
-Place the comment on its own line to skip the reference on the **next** line:
-
-```markdown
-<!-- refcheck-ignore -->
-[This reference will not be checked](./some/path.md)
-```
-
-Or place it inline to skip the reference on the **same** line:
-
-```markdown
-[This reference will not be checked](./some/path.md) <!-- refcheck-ignore -->
-```
-
-### Skip a section
-
-Wrap a block of lines with start/end directives:
-
-```markdown
-<!-- refcheck-ignore-start -->
-[ignored](./a.md)
-[also ignored](./b.md)
-<!-- refcheck-ignore-end -->
-```
-
-### Optional reason
-
-All directives accept an optional reason after a colon:
-
-```markdown
-<!-- refcheck-ignore: external link only available on VPN -->
-[internal docs](https://internal.example.com/docs)
-```
-
-> **Note:** Both `<!--` and `<!---` (triple-dash) syntax are supported. Directives inside code
-> blocks or inline code are not honored. Block start/end markers should be placed on their own
-> lines.
+- 🚀 **Pre-commit Integration** - Available as a pre-commit hook
+- 💬 **Inline Ignore Comments** - Suppress false positives with [`<!-- refcheck-ignore -->`](docs/Ignoring-References.md) directives
 
 ## Installation
 
@@ -159,5 +117,6 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md) before opening pull requests.
 For more detailed information, check out the documentation:
 
 - [CLI Reference](docs/CLI-Reference.md) - Complete command-line options and usage
+- [Ignoring References](docs/Ignoring-References.md) - Suppress false positives with inline comments
 - [Integration Guide](docs/Integration-Guide.md) - CI/CD and workflow integration
 - [Examples](docs/Examples.md) - Real-world usage examples

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ All directives accept an optional reason after a colon:
 ```
 
 > **Note:** Both `<!--` and `<!---` (triple-dash) syntax are supported. Directives inside code
-> blocks are not honored.
+> blocks or inline code are not honored. Block start/end markers should be placed on their own
+> lines.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,49 @@ options:
 - 🎨 **Colored Output** - Clear, color-coded results for easy scanning (disable with `--no-color`)
 - ⚙️ **CI/CD Ready** - Perfect for automated quality checks in your documentation workflows
 - 🚀 **Pre-commit Integration** - Available as a pre-commit hook for automated validation
+- 💬 **Inline Ignore Comments** - Suppress false positives with `<!-- refcheck-ignore -->` directives
+
+## Ignoring References
+
+Use HTML comment directives to suppress false positives on specific lines or sections.
+
+### Skip a single line
+
+Place the comment on its own line to skip the reference on the **next** line:
+
+```markdown
+<!-- refcheck-ignore -->
+[This reference will not be checked](./some/path.md)
+```
+
+Or place it inline to skip the reference on the **same** line:
+
+```markdown
+[This reference will not be checked](./some/path.md) <!-- refcheck-ignore -->
+```
+
+### Skip a section
+
+Wrap a block of lines with start/end directives:
+
+```markdown
+<!-- refcheck-ignore-start -->
+[ignored](./a.md)
+[also ignored](./b.md)
+<!-- refcheck-ignore-end -->
+```
+
+### Optional reason
+
+All directives accept an optional reason after a colon:
+
+```markdown
+<!-- refcheck-ignore: external link only available on VPN -->
+[internal docs](https://internal.example.com/docs)
+```
+
+> **Note:** Both `<!--` and `<!---` (triple-dash) syntax are supported. Directives inside code
+> blocks are not honored.
 
 ## Installation
 

--- a/docs/Ignoring-References.md
+++ b/docs/Ignoring-References.md
@@ -1,0 +1,61 @@
+# Ignoring References
+
+RefCheck supports HTML comment directives to suppress reference checking on specific lines or sections. This is useful
+for handling false positives or references that are intentionally broken (e.g., placeholder links, VPN-only URLs).
+
+## Table of Contents
+
+- [Skip a Single Line](#skip-a-single-line)
+- [Skip a Section](#skip-a-section)
+- [Optional Reason](#optional-reason)
+- [Syntax Details](#syntax-details)
+
+## Skip a Single Line
+
+Place the comment on its own line to skip the reference on the **next** line:
+
+```markdown
+<!-- refcheck-ignore -->
+[This reference will not be checked](./some/path.md)
+```
+
+Or place it inline to skip the reference on the **same** line:
+
+```markdown
+[This reference will not be checked](./some/path.md) <!-- refcheck-ignore -->
+```
+
+## Skip a Section
+
+Wrap a block of lines with start/end directives to skip all references within:
+
+```markdown
+<!-- refcheck-ignore-start -->
+[ignored](./a.md)
+[also ignored](./b.md)
+<!-- refcheck-ignore-end -->
+```
+
+References before and after the block are still checked as normal.
+
+## Optional Reason
+
+All directives accept an optional reason after a colon. This is purely for documentation purposes and does not affect
+behavior:
+
+```markdown
+<!-- refcheck-ignore: external link only available on VPN -->
+[internal docs](https://internal.example.com/docs)
+
+<!-- refcheck-ignore-start: placeholder links for upcoming feature -->
+[feature docs](./upcoming/feature.md)
+[feature API](./upcoming/api.md)
+<!-- refcheck-ignore-end: placeholder links for upcoming feature -->
+```
+
+## Syntax Details
+
+- Both `<!--` and `<!---` (triple-dash) syntax are supported.
+- Directives inside fenced code blocks (` ``` `) or inline code (`` ` ``) are **not** honored.
+- Block start/end markers should be placed on their own lines.
+- All reference types are affected: basic references, images, and inline links.

--- a/refcheck/parsers.py
+++ b/refcheck/parsers.py
@@ -9,6 +9,12 @@ CODE_BLOCK_PATTERN = re.compile(r"```(?P<content>[\s\S]*?)```")
 INLINE_CODE_PATTERN = re.compile(r"`(?P<content>[^`\n]+)`")
 HTML_COMMENT_PATTERN = re.compile(r"<!--(?P<content>[\s\S]*?)-->")
 
+# Refcheck ignore directives — support both <!-- and <!--- (2 or 3 dashes)
+REFCHECK_IGNORE_PATTERN = re.compile(r"<!---?\s*refcheck-ignore\s*(?::.*?)?\s*-->")
+REFCHECK_IGNORE_START_PATTERN = re.compile(r"<!---?\s*refcheck-ignore-start\s*(?::.*?)?\s*-->")
+REFCHECK_IGNORE_END_PATTERN = re.compile(r"<!---?\s*refcheck-ignore-end\s*-->")
+
+
 # Basic Markdown references
 BASIC_REFERENCE_PATTERN = re.compile(r"!*\[(?P<text>[^\]]+)\]\((?P<link>[^)]+)\)")  # []() and ![]()
 BASIC_IMAGE_PATTERN = re.compile(r"!\[(?P<text>[^(){}\[\]]+)\]\((?P<link>[^(){}\[\]]+)\)")  # ![]()
@@ -107,6 +113,10 @@ class MarkdownParser:
         # Combine code blocks, inline code, and HTML comments for filtering
         all_code = code_blocks + inline_code + html_comments
 
+        # Determine which lines should be ignored via refcheck-ignore directives
+        logger.info("Checking for refcheck-ignore directives ...")
+        ignored_lines = self._get_ignored_lines(content, all_code)
+
         # Get all references that look like this: [text](reference)
         logger.info("Extracting basic references ...")
         basic_reference_matches = self._find_matches_with_line_numbers(
@@ -120,6 +130,9 @@ class MarkdownParser:
             logger.info(ref_match.__repr__())
 
         basic_reference_matches = self._drop_code_references(basic_reference_matches, all_code)
+        basic_reference_matches = self._drop_ignored_references(
+            basic_reference_matches, ignored_lines
+        )
         logger.info("Processing reference matches...")
         basic_references = self._process_basic_references(file_path, basic_reference_matches)
 
@@ -128,12 +141,14 @@ class MarkdownParser:
         basic_image_matches = self._find_matches_with_line_numbers(BASIC_IMAGE_PATTERN, content)
         logger.info(f"Found {len(basic_image_matches)} basic images.")
         basic_image_matches = self._drop_code_references(basic_image_matches, all_code)
+        basic_image_matches = self._drop_ignored_references(basic_image_matches, ignored_lines)
         basic_images = self._process_basic_references(file_path, basic_image_matches)
 
         logger.info("Extracting inline links ...")
         inline_link_matches = self._find_matches_with_line_numbers(INLINE_LINK_PATTERN, content)
         logger.info(f"Found {len(inline_link_matches)} inline links.")
         inline_link_matches = self._drop_code_references(inline_link_matches, all_code)
+        inline_link_matches = self._drop_ignored_references(inline_link_matches, ignored_lines)
         inline_links = self._process_basic_references(file_path, inline_link_matches)
 
         return {
@@ -223,6 +238,104 @@ class MarkdownParser:
             )
             references.append(reference)
         return references
+
+    def _get_ignored_lines(
+        self, content: str, code_sections: list[ReferenceMatch]
+    ) -> set[int]:
+        """Determine which lines should be ignored based on refcheck-ignore directives.
+
+        Supports:
+        - Single-line: ``<!-- refcheck-ignore -->`` (standalone → next line, inline → same line)
+        - Block: ``<!-- refcheck-ignore-start -->`` ... ``<!-- refcheck-ignore-end -->``
+        """
+        ignored_lines: set[int] = set()
+
+        # --- Single-line ignore directives ---
+        ignore_matches = self._find_matches_with_line_numbers(REFCHECK_IGNORE_PATTERN, content)
+        # Exclude single-line directives that also match the start/end patterns
+        ignore_matches = [
+            m
+            for m in ignore_matches
+            if not REFCHECK_IGNORE_START_PATTERN.match(m.match.group(0))
+            and not REFCHECK_IGNORE_END_PATTERN.match(m.match.group(0))
+        ]
+        ignore_matches = self._drop_code_references(ignore_matches, code_sections)
+
+        for m in ignore_matches:
+            if self._is_standalone_comment(m.match, content):
+                ignored_lines.add(m.line_number + 1)
+            else:
+                ignored_lines.add(m.line_number)
+
+        # --- Block ignore directives ---
+        start_matches = self._find_matches_with_line_numbers(
+            REFCHECK_IGNORE_START_PATTERN, content
+        )
+        start_matches = self._drop_code_references(start_matches, code_sections)
+
+        end_matches = self._find_matches_with_line_numbers(REFCHECK_IGNORE_END_PATTERN, content)
+        end_matches = self._drop_code_references(end_matches, code_sections)
+
+        total_lines = content.count("\n") + 1
+
+        for start in start_matches:
+            # Find the first end directive that comes after this start directive
+            matching_end = None
+            for end in end_matches:
+                if end.line_number > start.line_number:
+                    matching_end = end
+                    break
+
+            if matching_end:
+                for line in range(start.line_number, matching_end.line_number + 1):
+                    ignored_lines.add(line)
+            else:
+                logger.warning(
+                    f"Unmatched refcheck-ignore-start at line {start.line_number}, "
+                    f"ignoring references until end of file."
+                )
+                for line in range(start.line_number, total_lines + 1):
+                    ignored_lines.add(line)
+
+        if ignored_lines:
+            logger.info(f"Ignoring references on lines: {sorted(ignored_lines)}")
+
+        return ignored_lines
+
+    def _is_standalone_comment(self, match: Match, content: str) -> bool:
+        """Check if a comment is the only non-whitespace content on its line."""
+        # Find the start of the line containing this match
+        line_start = content.rfind("\n", 0, match.start(0)) + 1
+        # Find the end of the line containing this match
+        line_end = content.find("\n", match.end(0))
+        if line_end == -1:
+            line_end = len(content)
+
+        before = content[line_start : match.start(0)]
+        after = content[match.end(0) : line_end]
+        return before.strip() == "" and after.strip() == ""
+
+    def _drop_ignored_references(
+        self, references: list[ReferenceMatch], ignored_lines: set[int]
+    ) -> list[ReferenceMatch]:
+        """Drop references that are on ignored lines."""
+        if not ignored_lines:
+            return references
+
+        filtered = []
+        dropped_counter = 0
+
+        for ref in references:
+            if ref.line_number in ignored_lines:
+                logger.info(f"Dropping ignored reference: {ref.match.group(0)}")
+                dropped_counter += 1
+            else:
+                filtered.append(ref)
+
+        if dropped_counter > 0:
+            logger.info(f"Dropped {dropped_counter} ignored references.")
+
+        return filtered
 
     def _find_matches_with_line_numbers(
         self, pattern: Pattern[str], text: str

--- a/refcheck/parsers.py
+++ b/refcheck/parsers.py
@@ -12,7 +12,7 @@ HTML_COMMENT_PATTERN = re.compile(r"<!--(?P<content>[\s\S]*?)-->")
 # Refcheck ignore directives — support both <!-- and <!--- (2 or 3 dashes)
 REFCHECK_IGNORE_PATTERN = re.compile(r"<!---?\s*refcheck-ignore\s*(?::.*?)?\s*-->")
 REFCHECK_IGNORE_START_PATTERN = re.compile(r"<!---?\s*refcheck-ignore-start\s*(?::.*?)?\s*-->")
-REFCHECK_IGNORE_END_PATTERN = re.compile(r"<!---?\s*refcheck-ignore-end\s*-->")
+REFCHECK_IGNORE_END_PATTERN = re.compile(r"<!---?\s*refcheck-ignore-end\s*(?::.*?)?\s*-->")
 
 
 # Basic Markdown references
@@ -285,14 +285,14 @@ class MarkdownParser:
                     break
 
             if matching_end:
-                for line in range(start.line_number, matching_end.line_number + 1):
+                for line in range(start.line_number + 1, matching_end.line_number):
                     ignored_lines.add(line)
             else:
                 logger.warning(
                     f"Unmatched refcheck-ignore-start at line {start.line_number}, "
                     f"ignoring references until end of file."
                 )
-                for line in range(start.line_number, total_lines + 1):
+                for line in range(start.line_number + 1, total_lines + 1):
                     ignored_lines.add(line)
 
         if ignored_lines:

--- a/refcheck/parsers.py
+++ b/refcheck/parsers.py
@@ -113,9 +113,11 @@ class MarkdownParser:
         # Combine code blocks, inline code, and HTML comments for filtering
         all_code = code_blocks + inline_code + html_comments
 
-        # Determine which lines should be ignored via refcheck-ignore directives
+        # Determine which lines should be ignored via refcheck-ignore directives.
+        # Only filter against code blocks and inline code (not HTML comments), since
+        # refcheck-ignore directives are themselves HTML comments.
         logger.info("Checking for refcheck-ignore directives ...")
-        ignored_lines = self._get_ignored_lines(content, all_code)
+        ignored_lines = self._get_ignored_lines(content, code_blocks + inline_code)
 
         # Get all references that look like this: [text](reference)
         logger.info("Extracting basic references ...")

--- a/refcheck/parsers.py
+++ b/refcheck/parsers.py
@@ -241,9 +241,7 @@ class MarkdownParser:
             references.append(reference)
         return references
 
-    def _get_ignored_lines(
-        self, content: str, code_sections: list[ReferenceMatch]
-    ) -> set[int]:
+    def _get_ignored_lines(self, content: str, code_sections: list[ReferenceMatch]) -> set[int]:
         """Determine which lines should be ignored based on refcheck-ignore directives.
 
         Supports:
@@ -270,9 +268,7 @@ class MarkdownParser:
                 ignored_lines.add(m.line_number)
 
         # --- Block ignore directives ---
-        start_matches = self._find_matches_with_line_numbers(
-            REFCHECK_IGNORE_START_PATTERN, content
-        )
+        start_matches = self._find_matches_with_line_numbers(REFCHECK_IGNORE_START_PATTERN, content)
         start_matches = self._drop_code_references(start_matches, code_sections)
 
         end_matches = self._find_matches_with_line_numbers(REFCHECK_IGNORE_END_PATTERN, content)

--- a/tests/fixtures/ignore_comments/block_ignore.md
+++ b/tests/fixtures/ignore_comments/block_ignore.md
@@ -3,9 +3,9 @@
 [kept_before](before.md)
 
 <!-- refcheck-ignore-start -->
-[ignored_one](ignored1.md)
-[ignored_two](ignored2.md)
-![ignored_img](ignored.png)
+
+[ignored_one](ignored1.md) [ignored_two](ignored2.md) ![ignored_img](ignored.png)
+
 <!-- refcheck-ignore-end -->
 
 [kept_after](after.md)

--- a/tests/fixtures/ignore_comments/block_ignore.md
+++ b/tests/fixtures/ignore_comments/block_ignore.md
@@ -1,0 +1,11 @@
+# Block Ignore Test
+
+[kept_before](before.md)
+
+<!-- refcheck-ignore-start -->
+[ignored_one](ignored1.md)
+[ignored_two](ignored2.md)
+![ignored_img](ignored.png)
+<!-- refcheck-ignore-end -->
+
+[kept_after](after.md)

--- a/tests/fixtures/ignore_comments/ignore_in_code_block.md
+++ b/tests/fixtures/ignore_comments/ignore_in_code_block.md
@@ -4,6 +4,7 @@ Directives inside code blocks should NOT be honored.
 
 ```markdown
 <!-- refcheck-ignore -->
+
 [should_be_filtered_by_code_block](fake.md)
 ```
 

--- a/tests/fixtures/ignore_comments/ignore_in_code_block.md
+++ b/tests/fixtures/ignore_comments/ignore_in_code_block.md
@@ -1,0 +1,10 @@
+# Ignore In Code Block Test
+
+Directives inside code blocks should NOT be honored.
+
+```markdown
+<!-- refcheck-ignore -->
+[should_be_filtered_by_code_block](fake.md)
+```
+
+[real_link](real.md)

--- a/tests/fixtures/ignore_comments/ignore_with_reason.md
+++ b/tests/fixtures/ignore_comments/ignore_with_reason.md
@@ -1,0 +1,13 @@
+# Ignore With Reason Test
+
+<!--- refcheck-ignore: this is a known false positive -->
+[ignored_link](ignored.md)
+
+[kept_link](kept.md)
+
+<!--- refcheck-ignore-start: entire section produces false positives -->
+[ignored_one](ignored1.md)
+[ignored_two](ignored2.md)
+<!--- refcheck-ignore-end -->
+
+[also_kept](also_kept.md)

--- a/tests/fixtures/ignore_comments/ignore_with_reason.md
+++ b/tests/fixtures/ignore_comments/ignore_with_reason.md
@@ -6,8 +6,9 @@
 [kept_link](kept.md)
 
 <!--- refcheck-ignore-start: entire section produces false positives -->
-[ignored_one](ignored1.md)
-[ignored_two](ignored2.md)
+
+[ignored_one](ignored1.md) [ignored_two](ignored2.md)
+
 <!--- refcheck-ignore-end -->
 
 [also_kept](also_kept.md)

--- a/tests/fixtures/ignore_comments/inline_ignore.md
+++ b/tests/fixtures/ignore_comments/inline_ignore.md
@@ -1,0 +1,7 @@
+# Inline Ignore Test
+
+[kept_link](kept.md)
+
+[ignored_link](ignored.md) <!-- refcheck-ignore -->
+
+[also_kept](also_kept.md)

--- a/tests/fixtures/ignore_comments/single_line_ignore.md
+++ b/tests/fixtures/ignore_comments/single_line_ignore.md
@@ -1,0 +1,8 @@
+# Single Line Ignore Test
+
+[kept_link](kept.md)
+
+<!-- refcheck-ignore -->
+[ignored_link](ignored.md)
+
+[also_kept](also_kept.md)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -742,3 +742,35 @@ class TestRefcheckIgnore:
         assert "ignored.md" not in links
         assert "ignored1.md" not in links
         assert "ignored2.md" not in links
+
+    def test_block_end_with_reason(self, temp_markdown_file):
+        """Block end directive with an optional reason is recognized."""
+        content = """\
+[kept](kept.md)
+<!-- refcheck-ignore-start: reason -->
+[ignored](ignored.md)
+<!-- refcheck-ignore-end: done -->
+[also_kept](also_kept.md)
+"""
+        file_path = temp_markdown_file(content)
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(file_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert links == ["kept.md", "also_kept.md"]
+
+    def test_block_markers_do_not_suppress_own_lines(self, temp_markdown_file):
+        """References on start/end marker lines are not suppressed."""
+        content = """\
+[before](before.md) <!-- refcheck-ignore-start -->
+[ignored](ignored.md)
+<!-- refcheck-ignore-end --> [after](after.md)
+"""
+        file_path = temp_markdown_file(content)
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(file_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert "before.md" in links
+        assert "after.md" in links
+        assert "ignored.md" not in links

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -498,3 +498,247 @@ class TestReferenceDataClass:
         )
         str_repr = str(ref)
         assert "Remote" in str_repr
+
+
+class TestRefcheckIgnore:
+    """Tests for refcheck-ignore comment directives."""
+
+    def test_standalone_ignore_skips_next_line(self, temp_markdown_file):
+        """A standalone <!-- refcheck-ignore --> skips the reference on the next line."""
+        content = """\
+[kept](kept.md)
+<!-- refcheck-ignore -->
+[ignored](ignored.md)
+[also_kept](also_kept.md)
+"""
+        file_path = temp_markdown_file(content)
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(file_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert links == ["kept.md", "also_kept.md"]
+
+    def test_inline_ignore_skips_same_line(self, temp_markdown_file):
+        """An inline <!-- refcheck-ignore --> skips the reference on the same line."""
+        content = """\
+[kept](kept.md)
+[ignored](ignored.md) <!-- refcheck-ignore -->
+[also_kept](also_kept.md)
+"""
+        file_path = temp_markdown_file(content)
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(file_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert links == ["kept.md", "also_kept.md"]
+
+    def test_block_ignore_skips_section(self, temp_markdown_file):
+        """References between start/end block directives are skipped."""
+        content = """\
+[kept_before](before.md)
+<!-- refcheck-ignore-start -->
+[ignored1](ignored1.md)
+[ignored2](ignored2.md)
+<!-- refcheck-ignore-end -->
+[kept_after](after.md)
+"""
+        file_path = temp_markdown_file(content)
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(file_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert links == ["before.md", "after.md"]
+
+    def test_block_ignore_skips_images(self, temp_markdown_file):
+        """Block ignore also skips image references."""
+        content = """\
+![kept](kept.png)
+<!-- refcheck-ignore-start -->
+![ignored](ignored.png)
+<!-- refcheck-ignore-end -->
+![also_kept](also_kept.png)
+"""
+        file_path = temp_markdown_file(content)
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(file_path)
+
+        links = [r.link for r in result["basic_images"]]
+        assert links == ["kept.png", "also_kept.png"]
+
+    def test_ignore_with_reason(self, temp_markdown_file):
+        """Ignore directives with an optional reason are supported."""
+        content = """\
+[kept](kept.md)
+<!-- refcheck-ignore: this is a known false positive -->
+[ignored](ignored.md)
+[also_kept](also_kept.md)
+"""
+        file_path = temp_markdown_file(content)
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(file_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert links == ["kept.md", "also_kept.md"]
+
+    def test_triple_dash_syntax(self, temp_markdown_file):
+        """<!--- refcheck-ignore --> with triple-dash is supported."""
+        content = """\
+[kept](kept.md)
+<!--- refcheck-ignore -->
+[ignored](ignored.md)
+[also_kept](also_kept.md)
+"""
+        file_path = temp_markdown_file(content)
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(file_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert links == ["kept.md", "also_kept.md"]
+
+    def test_triple_dash_block_with_reason(self, temp_markdown_file):
+        """<!--- refcheck-ignore-start: reason --> with triple-dash and reason."""
+        content = """\
+[kept](kept.md)
+<!--- refcheck-ignore-start: entire section is false positives -->
+[ignored1](ignored1.md)
+[ignored2](ignored2.md)
+<!--- refcheck-ignore-end -->
+[also_kept](also_kept.md)
+"""
+        file_path = temp_markdown_file(content)
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(file_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert links == ["kept.md", "also_kept.md"]
+
+    def test_ignore_inside_code_block_not_honored(self, temp_markdown_file):
+        """Ignore directives inside code blocks should NOT be honored."""
+        content = """\
+```markdown
+<!-- refcheck-ignore -->
+[in_code_block](fake.md)
+```
+[real_link](real.md)
+"""
+        file_path = temp_markdown_file(content)
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(file_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert links == ["real.md"]
+
+    def test_unmatched_block_start_ignores_to_eof(self, temp_markdown_file):
+        """An unmatched refcheck-ignore-start ignores references to end of file."""
+        content = """\
+[kept](kept.md)
+<!-- refcheck-ignore-start -->
+[ignored1](ignored1.md)
+[ignored2](ignored2.md)
+"""
+        file_path = temp_markdown_file(content)
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(file_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert links == ["kept.md"]
+
+    def test_multiple_ignore_comments(self, temp_markdown_file):
+        """Multiple ignore comments in a single file work independently."""
+        content = """\
+[kept1](kept1.md)
+<!-- refcheck-ignore -->
+[ignored1](ignored1.md)
+[kept2](kept2.md)
+<!-- refcheck-ignore -->
+[ignored2](ignored2.md)
+[kept3](kept3.md)
+"""
+        file_path = temp_markdown_file(content)
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(file_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert links == ["kept1.md", "kept2.md", "kept3.md"]
+
+    def test_no_over_suppression(self, temp_markdown_file):
+        """Inline ignore on line N does not suppress line N+1."""
+        content = """\
+[ref1](ref1.md) <!-- refcheck-ignore -->
+[ref2](ref2.md)
+"""
+        file_path = temp_markdown_file(content)
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(file_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert links == ["ref2.md"]
+
+    def test_fixture_single_line_ignore(self):
+        """Test with the single_line_ignore.md fixture file."""
+        fixture_path = os.path.join(
+            os.path.dirname(__file__), "fixtures", "ignore_comments", "single_line_ignore.md"
+        )
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(fixture_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert "kept.md" in links
+        assert "also_kept.md" in links
+        assert "ignored.md" not in links
+
+    def test_fixture_inline_ignore(self):
+        """Test with the inline_ignore.md fixture file."""
+        fixture_path = os.path.join(
+            os.path.dirname(__file__), "fixtures", "ignore_comments", "inline_ignore.md"
+        )
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(fixture_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert "kept.md" in links
+        assert "also_kept.md" in links
+        assert "ignored.md" not in links
+
+    def test_fixture_block_ignore(self):
+        """Test with the block_ignore.md fixture file."""
+        fixture_path = os.path.join(
+            os.path.dirname(__file__), "fixtures", "ignore_comments", "block_ignore.md"
+        )
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(fixture_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert "before.md" in links
+        assert "after.md" in links
+        assert "ignored1.md" not in links
+        assert "ignored2.md" not in links
+
+        img_links = [r.link for r in result["basic_images"]]
+        assert "ignored.png" not in img_links
+
+    def test_fixture_ignore_in_code_block(self):
+        """Test with the ignore_in_code_block.md fixture file."""
+        fixture_path = os.path.join(
+            os.path.dirname(__file__), "fixtures", "ignore_comments", "ignore_in_code_block.md"
+        )
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(fixture_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert links == ["real.md"]
+
+    def test_fixture_ignore_with_reason(self):
+        """Test with the ignore_with_reason.md fixture file."""
+        fixture_path = os.path.join(
+            os.path.dirname(__file__), "fixtures", "ignore_comments", "ignore_with_reason.md"
+        )
+        parser = MarkdownParser()
+        result = parser.parse_markdown_file(fixture_path)
+
+        links = [r.link for r in result["basic_references"]]
+        assert "kept.md" in links
+        assert "also_kept.md" in links
+        assert "ignored.md" not in links
+        assert "ignored1.md" not in links
+        assert "ignored2.md" not in links


### PR DESCRIPTION
## Summary

Add `<!-- refcheck-ignore -->` and `<!-- refcheck-ignore-start/end -->` HTML comment directives to suppress reference checking on specific lines or sections, useful for handling false positives.

Closes #103

### Type of change

- [x] New feature
- [x] Documentation

## Changes

- **3 new regex patterns** in `parsers.py` for `refcheck-ignore`, `refcheck-ignore-start`, and `refcheck-ignore-end` — support both `<!--` and `<!---` syntax with optional `: reason` text
- **`_get_ignored_lines()` method** — extracts ignore directives, determines standalone vs inline mode, builds set of ignored line numbers. Standalone comments skip the next line; inline comments skip the same line. Block pairs skip all lines between markers (exclusive of boundary lines). Unmatched block start ignores to EOF with a warning.
- **`_drop_ignored_references()` method** — filters references by line number against the ignored set, with logging
- **Updated `parse_markdown_file()`** — integrates ignore filtering after code block filtering for all reference types (basic, images, inline links)
- **18 unit tests** in `TestRefcheckIgnore` covering standalone, inline, block, reason text, triple-dash, code block exclusion, unmatched block, multiple ignores, no over-suppression, end-with-reason, and boundary line edge cases
- **5 test fixture files** in `tests/fixtures/ignore_comments/`
- **README.md** — new "Ignoring References" section with examples for all three modes

## How to test

1. `make qa && make test` — all 168 tests pass, 95.37% coverage, all QA checks clean
2. Create a markdown file with ignore comments:
   ```markdown
   <!-- refcheck-ignore -->
   [this link is ignored](./nonexistent.md)

   [this link is checked](./also-nonexistent.md)

   <!-- refcheck-ignore-start -->
   [ignored block](./fake1.md)
   [ignored block](./fake2.md)
   <!-- refcheck-ignore-end -->
   ```
3. Run `refcheck <file>` — only `also-nonexistent.md` should be reported as broken
4. Run `refcheck <file> -v` — verbose output should log dropped ignored references