### PR TITLE
docs: add Azure DevOps Pipelines integration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-silver.svg)](https://opensource.org/licenses/MIT)
 [![CI/CD](https://github.com/flumi3/markdown-refcheck/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/flumi3/markdown-refcheck/actions/workflows/ci-cd.yml)
 
-Markdown RefCheck is a simple tool that checks Markdown references to find any broken links.
-It helps keeping your documentation free from broken section refs, missing images and files, and unavailable website
-links.
+Markdown RefCheck is a simple tool that checks Markdown references to find any broken links. It helps keeping your
+documentation free from broken section refs, missing images and files, and unavailable website links.
 
 ## Features
 
 - 🔍 **Reference Detection** — Validate links, images, file refs, and header anchors
 - 🌐 **Remote URL Checking** — Validate external HTTP/HTTPS links (optional)
-- 💬 **Inline Ignore Comments** — Suppress false positives with [`<!-- refcheck-ignore -->`](docs/user-guide/Ignoring-References.md) directives
+- 💬 **Inline Ignore Comments** — Suppress false positives with
+  [`<!-- refcheck-ignore -->`](docs/user-guide/Ignoring-References.md) directives
 - ⚙️ **CI/CD Ready** — Exit codes and `--no-color` for automation
 - 🚀 **Pre-commit Integration** — Available as a [pre-commit hook](docs/user-guide/Integration-Guide.md#pre-commit-hook)
 
@@ -77,7 +77,7 @@ See the [Integration Guide](docs/user-guide/Integration-Guide.md) for CI/CD and 
 
 - [CLI Reference](docs/user-guide/CLI-Reference.md) — Command-line options
 - [Ignoring References](docs/user-guide/Ignoring-References.md) — Suppress false positives
-- [Integration Guide](docs/user-guide/Integration-Guide.md) — Pre-commit, CI/CD, Makefile
+- [Integration Guide](docs/user-guide/Integration-Guide.md) — Pre-commit, CI/CD, Azure DevOps, Makefile
 - [Development Guide](docs/developer-guide/Development-Guide.md) — Architecture, setup, conventions
 
 ## Contributing

--- a/docs/user-guide/Integration-Guide.md
+++ b/docs/user-guide/Integration-Guide.md
@@ -68,6 +68,64 @@ jobs:
       - run: refcheck . --check-remote --no-color
 ```
 
+## Azure DevOps Pipelines
+
+Validate documentation references in Azure DevOps pull request builds:
+
+```yaml
+# azure-pipelines.yml
+trigger:
+  branches:
+    include:
+      - main
+
+pr:
+  paths:
+    include:
+      - "**.md"
+
+pool:
+  vmImage: "ubuntu-latest"
+
+steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: "3.11"
+
+  - script: pip install refcheck
+    displayName: "Install RefCheck"
+
+  - script: refcheck . --no-color -e node_modules/
+    displayName: "Check Markdown references"
+```
+
+For a scheduled pipeline that also validates remote URLs:
+
+```yaml
+# azure-pipelines-weekly-docs.yml
+schedules:
+  - cron: "0 0 * * 0"
+    displayName: "Weekly documentation audit"
+    branches:
+      include:
+        - main
+    always: true
+
+pool:
+  vmImage: "ubuntu-latest"
+
+steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: "3.11"
+
+  - script: pip install refcheck
+    displayName: "Install RefCheck"
+
+  - script: refcheck . --check-remote --no-color
+    displayName: "Check Markdown references (including remote)"
+```
+
 ## Makefile
 
 ```makefile


### PR DESCRIPTION
## Summary

Adds an **Azure DevOps Pipelines** section to the Integration Guide with:

- A **PR-triggered pipeline** that validates markdown references on pull requests touching `**.md` files
- A **scheduled weekly pipeline** that includes remote URL validation via `--check-remote`

Also updates the README's Integration Guide link to mention Azure DevOps.

Cherry-picked from the merged `docs/refactor-documentation-structure` branch (#112).