### PR TITLE
ci: add docs QA pipeline with Prettier, markdownlint, and refcheck

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -60,6 +60,36 @@ jobs:
           (echo "Some commits don't follow Conventional Commit format! Refer to CONTRIBUTING.md for guidelines." && exit 1)
 
   # Explicit job definitions for each Python version (matrix not supported on reusable workflows)
+  docs-qa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Install Python dependencies
+        run: poetry install --no-interaction
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Run Docs QA
+        run: make docs-qa-check
+
   test-py310:
     uses: ./.github/workflows/lint-and-test.yml
     with:

--- a/.gitignore
+++ b/.gitignore
@@ -161,5 +161,7 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-.refcheckignore
+# Node.js (docs QA tooling)
+node_modules/
+
 .vscode/

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,43 @@
+# MD013 - Line length: disabled, Prettier handles line wrapping
+MD013: false
+
+# MD024 - Multiple headings with the same content: allow siblings only
+MD024:
+  siblings_only: true
+
+# MD028 - Blank line inside blockquote: disabled, intentional visual separation
+MD028: false
+
+# MD036 - Emphasis used instead of a heading: disabled, project uses bold callout lines
+MD036: false
+
+# MD041 - First line in a file should be a top-level heading: disabled
+MD041: false
+
+# MD046 - Code block style: disabled, admonition blocks cause false positives
+MD046: false
+
+# Allowed HTML elements
+MD033:
+  allowed_elements:
+    - br
+    - details
+    - summary
+    - sup
+    - sub
+    - kbd
+
+# Heading style: ATX-style (## heading)
+MD003:
+  style: atx
+
+# Emphasis style: underscores for italic, asterisks for bold
+MD049:
+  style: underscore
+
+MD050:
+  style: asterisk
+
+# Code fence style: backticks
+MD048:
+  style: backtick

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,6 @@
+node_modules/
+.venv/
+htmlcov/
+tests/fixtures/**
+tests/sample_markdown.md
+CHANGELOG.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules/
+.venv/
+__pycache__/
+htmlcov/
+dist/
+*.py
+tests/fixtures/**
+tests/sample_markdown.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ dist/
 *.py
 tests/fixtures/**
 tests/sample_markdown.md
+CHANGELOG.md

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,3 @@
+proseWrap: always
+printWidth: 100
+tabWidth: 2

--- a/.refcheckignore
+++ b/.refcheckignore
@@ -1,0 +1,7 @@
+.github/
+.venv/
+.pytest_cache/
+node_modules/
+htmlcov/
+tests/fixtures/
+tests/sample_markdown.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+
 ## v0.5.0 (2026-05-22)
 
 ### Features
@@ -11,46 +12,45 @@
 * feat(parsers): add refcheck-ignore comment directives for line/section skipping
 
 Add support for inline markdown comments to skip reference checking: - <!-- refcheck-ignore --> on
-standalone line: skips next line - <!-- refcheck-ignore --> inline with content: skips that line -
-
+  standalone line: skips next line - <!-- refcheck-ignore --> inline with content: skips that line -
   <!-- refcheck-ignore-start --> / <!-- refcheck-ignore-end -->: skips block - All directives
-
-support optional reason text - Both <!-- and <!--- syntax supported - Directives inside code blocks
-are not honored
+  support optional reason text - Both <!-- and <!--- syntax supported - Directives inside code
+  blocks are not honored
 
 Implements #103
 
-- test(parsers): add comprehensive tests for refcheck-ignore directives
+* test(parsers): add comprehensive tests for refcheck-ignore directives
 
 Add TestRefcheckIgnore class with 16 tests covering: - Standalone ignore (next-line), inline ignore
-(same-line) - Block ignore with start/end directives - Image and inline link filtering - Optional
-reason text, triple-dash syntax - Ignore directives inside code blocks (not honored) - Unmatched
-block start (ignore to EOF) - Multiple ignore comments, no over-suppression - Fixture file tests for
-all scenarios
+  (same-line) - Block ignore with start/end directives - Image and inline link filtering - Optional
+  reason text, triple-dash syntax - Ignore directives inside code blocks (not honored) - Unmatched
+  block start (ignore to EOF) - Multiple ignore comments, no over-suppression - Fixture file tests
+  for all scenarios
 
-Also fix \_get_ignored_lines to filter against code blocks and inline code only (not HTML comments),
-since ignore directives are themselves HTML comments.
+Also fix _get_ignored_lines to filter against code blocks and inline code only (not HTML comments),
+  since ignore directives are themselves HTML comments.
 
-- docs(readme): add ignore comments documentation
+* docs(readme): add ignore comments documentation
 
 Document the three refcheck-ignore modes: - Standalone: skip next line - Inline: skip same line -
-Block: skip entire section - Optional reason text syntax - Note about triple-dash and code block
-behavior
+  Block: skip entire section - Optional reason text syntax - Note about triple-dash and code block
+  behavior
 
-- style(parsers): apply ruff formatting
+* style(parsers): apply ruff formatting
 
-- fix(parsers): address review findings for ignore directives
+* fix(parsers): address review findings for ignore directives
 
-* Add optional reason support to refcheck-ignore-end pattern - Make block suppression exclusive of
+- Add optional reason support to refcheck-ignore-end pattern - Make block suppression exclusive of
   start/end marker lines (only lines between markers are suppressed) - Add regression tests for
   end-with-reason and boundary lines - Update README to mention inline code exclusion and standalone
   marker requirement
 
-- docs: move ignore reference docs from README to docs/Ignoring-References.md
+* docs: move ignore reference docs from README to docs/Ignoring-References.md
 
-* Create dedicated docs/Ignoring-References.md with full documentation - Keep only a feature bullet
-  - link in README - Add to documentation listing in README - Fix fixture files that had
-    formatter-injected blank lines
+- Create dedicated docs/Ignoring-References.md with full documentation - Keep only a feature bullet
+  + link in README - Add to documentation listing in README - Fix fixture files that had
+  formatter-injected blank lines
+
 
 ## v0.4.5 (2026-05-22)
 
@@ -63,12 +63,12 @@ behavior
 * chore(deps): bump pytest in the pip group across 1 directory (#105)
 
 Bumps the pip group with 1 update in the / directory:
-[pytest](https://github.com/pytest-dev/pytest).
+  [pytest](https://github.com/pytest-dev/pytest).
 
-Updates `pytest` from 8.4.2 to 9.0.3 -
-[Release notes](https://github.com/pytest-dev/pytest/releases) -
-[Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
-[Commits](https://github.com/pytest-dev/pytest/compare/8.4.2...9.0.3)
+Updates `pytest` from 8.4.2 to 9.0.3 - [Release
+  notes](https://github.com/pytest-dev/pytest/releases) -
+  [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
+  [Commits](https://github.com/pytest-dev/pytest/compare/8.4.2...9.0.3)
 
 --- updated-dependencies: - dependency-name: pytest dependency-version: 9.0.3
 
@@ -76,51 +76,50 @@ dependency-type: direct:development
 
 dependency-group: pip ...
 
-- chore(deps): bump urllib3 in the pip group across 1 directory (#106)
+* chore(deps): bump urllib3 in the pip group across 1 directory (#106)
 
 Bumps the pip group with 1 update in the / directory: [urllib3](https://github.com/urllib3/urllib3).
 
 Updates `urllib3` from 2.6.3 to 2.7.0 - [Release notes](https://github.com/urllib3/urllib3/releases)
-
-- [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) -
+  - [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) -
   [Commits](https://github.com/urllib3/urllib3/compare/2.6.3...2.7.0)
 
 --- updated-dependencies: - dependency-name: urllib3 dependency-version: 2.7.0
 
 dependency-type: indirect
 
-- chore(deps): bump idna in the pip group across 1 directory (#107)
+* chore(deps): bump idna in the pip group across 1 directory (#107)
 
 Bumps the pip group with 1 update in the / directory: [idna](https://github.com/kjd/idna).
 
 Updates `idna` from 3.10 to 3.15 - [Release notes](https://github.com/kjd/idna/releases) -
-[Changelog](https://github.com/kjd/idna/blob/master/HISTORY.md) -
-[Commits](https://github.com/kjd/idna/compare/v3.10...v3.15)
+  [Changelog](https://github.com/kjd/idna/blob/master/HISTORY.md) -
+  [Commits](https://github.com/kjd/idna/compare/v3.10...v3.15)
 
 --- updated-dependencies: - dependency-name: idna dependency-version: '3.15'
 
-- fix(parsers): exclude bare emails from inline link detection
+* fix(parsers): exclude bare emails from inline link detection
 
 Bare email addresses in angle brackets (e.g. <user@example.com>) were matched by INLINE_LINK_PATTERN
-and flagged as broken local references. Remove the email-matching alternative from the regex so only
-URLs (http://, https://) and explicit mailto: links are matched.
+  and flagged as broken local references. Remove the email-matching alternative from the regex so
+  only URLs (http://, https://) and explicit mailto: links are matched.
 
 Closes #108
 
-- chore(tests): update inline links fixture for email handling
+* chore(tests): update inline links fixture for email handling
 
 Update the fixture to reflect that bare emails in angle brackets are not validated as references by
-refcheck.
+  refcheck.
 
-- fix(ci): analyze PR commits for version preview
+* fix(ci): analyze PR commits for version preview
 
 The version preview workflow was using semantic-release which only analyzes commits on the
-configured release branch (main). In a PR context this meant it never detected version bumps.
+  configured release branch (main). In a PR context this meant it never detected version bumps.
 
 Replace with direct commit message analysis of origin/main..HEAD to correctly preview the version
-bump that would occur after merge.
+  bump that would occur after merge.
 
----
+---------
 
 Signed-off-by: dependabot[bot] <support@github.com>
 
@@ -135,8 +134,8 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 Bumps the pip group with 1 update in the / directory: [idna](https://github.com/kjd/idna).
 
 Updates `idna` from 3.10 to 3.15 - [Release notes](https://github.com/kjd/idna/releases) -
-[Changelog](https://github.com/kjd/idna/blob/master/HISTORY.md) -
-[Commits](https://github.com/kjd/idna/compare/v3.10...v3.15)
+  [Changelog](https://github.com/kjd/idna/blob/master/HISTORY.md) -
+  [Commits](https://github.com/kjd/idna/compare/v3.10...v3.15)
 
 --- updated-dependencies: - dependency-name: idna dependency-version: '3.15'
 
@@ -153,12 +152,12 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   [`070c305`](https://github.com/flumi3/markdown-refcheck/commit/070c305f6039dd8dbcbe702421cf4c7649ecde8c))
 
 Bumps the pip group with 1 update in the / directory:
-[pytest](https://github.com/pytest-dev/pytest).
+  [pytest](https://github.com/pytest-dev/pytest).
 
-Updates `pytest` from 8.4.2 to 9.0.3 -
-[Release notes](https://github.com/pytest-dev/pytest/releases) -
-[Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
-[Commits](https://github.com/pytest-dev/pytest/compare/8.4.2...9.0.3)
+Updates `pytest` from 8.4.2 to 9.0.3 - [Release
+  notes](https://github.com/pytest-dev/pytest/releases) -
+  [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
+  [Commits](https://github.com/pytest-dev/pytest/compare/8.4.2...9.0.3)
 
 --- updated-dependencies: - dependency-name: pytest dependency-version: 9.0.3
 
@@ -177,8 +176,7 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 Bumps the pip group with 1 update in the / directory: [urllib3](https://github.com/urllib3/urllib3).
 
 Updates `urllib3` from 2.6.3 to 2.7.0 - [Release notes](https://github.com/urllib3/urllib3/releases)
-
-- [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) -
+  - [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) -
   [Commits](https://github.com/urllib3/urllib3/compare/2.6.3...2.7.0)
 
 --- updated-dependencies: - dependency-name: urllib3 dependency-version: 2.7.0
@@ -191,6 +189,7 @@ Signed-off-by: dependabot[bot] <support@github.com>
 
 Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 
+
 ## v0.4.4 (2026-04-09)
 
 ### Bug Fixes
@@ -201,14 +200,14 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 
 * fix(parsers): ignore references inside HTML comments
 
-* fix(parsers): use position-based filtering in \_drop_code_references
+* fix(parsers): use position-based filtering in _drop_code_references
 
 Replace substring membership check with span comparison to prevent incorrectly dropping references
-that share the same text as a commented-out or code-block reference at a different position.
+  that share the same text as a commented-out or code-block reference at a different position.
 
-- chore: make test case a bit more real
+* chore: make test case a bit more real
 
-- ci(version-preview): pin python-semantic-release to v7
+* ci(version-preview): pin python-semantic-release to v7
 
 ### Chores
 
@@ -217,12 +216,12 @@ that share the same text as a commented-out or code-block reference at a differe
   [`ce3e78d`](https://github.com/flumi3/markdown-refcheck/commit/ce3e78df411b41e9891e7053269cf9fb5bc3147f))
 
 Bumps the pip group with 1 update in the / directory:
-[filelock](https://github.com/tox-dev/py-filelock).
+  [filelock](https://github.com/tox-dev/py-filelock).
 
-Updates `filelock` from 3.20.1 to 3.20.3 -
-[Release notes](https://github.com/tox-dev/py-filelock/releases) -
-[Changelog](https://github.com/tox-dev/filelock/blob/main/docs/changelog.rst) -
-[Commits](https://github.com/tox-dev/py-filelock/compare/3.20.1...3.20.3)
+Updates `filelock` from 3.20.1 to 3.20.3 - [Release
+  notes](https://github.com/tox-dev/py-filelock/releases) -
+  [Changelog](https://github.com/tox-dev/filelock/blob/main/docs/changelog.rst) -
+  [Commits](https://github.com/tox-dev/py-filelock/compare/3.20.1...3.20.3)
 
 --- updated-dependencies: - dependency-name: filelock dependency-version: 3.20.3
 
@@ -241,8 +240,7 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 Bumps the pip group with 1 update in the / directory: [requests](https://github.com/psf/requests).
 
 Updates `requests` from 2.32.4 to 2.33.0 - [Release notes](https://github.com/psf/requests/releases)
-
-- [Changelog](https://github.com/psf/requests/blob/main/HISTORY.md) -
+  - [Changelog](https://github.com/psf/requests/blob/main/HISTORY.md) -
   [Commits](https://github.com/psf/requests/compare/v2.32.4...v2.33.0)
 
 --- updated-dependencies: - dependency-name: requests dependency-version: 2.33.0
@@ -254,6 +252,7 @@ dependency-group: pip ...
 Signed-off-by: dependabot[bot] <support@github.com>
 
 Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+
 
 ## v0.4.3 (2026-03-06)
 
@@ -269,12 +268,12 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([`5709637`](https://github.com/flumi3/markdown-refcheck/commit/5709637b15fe6be2d3f4ddbb13f27c521d35579c))
 
 Bumps the pip group with 1 update in the / directory:
-[virtualenv](https://github.com/pypa/virtualenv).
+  [virtualenv](https://github.com/pypa/virtualenv).
 
-Updates `virtualenv` from 20.33.1 to 20.36.1 -
-[Release notes](https://github.com/pypa/virtualenv/releases) -
-[Changelog](https://github.com/pypa/virtualenv/blob/main/docs/changelog.rst) -
-[Commits](https://github.com/pypa/virtualenv/compare/20.33.1...20.36.1)
+Updates `virtualenv` from 20.33.1 to 20.36.1 - [Release
+  notes](https://github.com/pypa/virtualenv/releases) -
+  [Changelog](https://github.com/pypa/virtualenv/blob/main/docs/changelog.rst) -
+  [Commits](https://github.com/pypa/virtualenv/compare/20.33.1...20.36.1)
 
 --- updated-dependencies: - dependency-name: virtualenv dependency-version: 20.36.1
 
@@ -307,6 +306,7 @@ Signed-off-by: dependabot[bot] <support@github.com>
 - Improve README
   ([`6f93bf6`](https://github.com/flumi3/markdown-refcheck/commit/6f93bf60f76cd6fd8e0819fe7bc835a4459c6dc8))
 
+
 ## v0.4.2 (2026-01-20)
 
 ### Bug Fixes
@@ -322,12 +322,12 @@ This supplements the previous 'fix status codes' commit with proper semantic ver
   ([`818abab`](https://github.com/flumi3/markdown-refcheck/commit/818ababf557795f8c3e7a2ce5f6e1affdc8aabcb))
 
 Bumps the pip group with 1 update in the / directory:
-[filelock](https://github.com/tox-dev/py-filelock).
+  [filelock](https://github.com/tox-dev/py-filelock).
 
-Updates `filelock` from 3.20.0 to 3.20.1 -
-[Release notes](https://github.com/tox-dev/py-filelock/releases) -
-[Changelog](https://github.com/tox-dev/filelock/blob/main/docs/changelog.rst) -
-[Commits](https://github.com/tox-dev/py-filelock/compare/3.20.0...3.20.1)
+Updates `filelock` from 3.20.0 to 3.20.1 - [Release
+  notes](https://github.com/tox-dev/py-filelock/releases) -
+  [Changelog](https://github.com/tox-dev/filelock/blob/main/docs/changelog.rst) -
+  [Commits](https://github.com/tox-dev/py-filelock/compare/3.20.0...3.20.1)
 
 --- updated-dependencies: - dependency-name: filelock dependency-version: 3.20.1
 
@@ -343,8 +343,7 @@ Signed-off-by: dependabot[bot] <support@github.com>
 Bumps the pip group with 1 update in the / directory: [urllib3](https://github.com/urllib3/urllib3).
 
 Updates `urllib3` from 2.6.0 to 2.6.3 - [Release notes](https://github.com/urllib3/urllib3/releases)
-
-- [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) -
+  - [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) -
   [Commits](https://github.com/urllib3/urllib3/compare/2.6.0...2.6.3)
 
 --- updated-dependencies: - dependency-name: urllib3 dependency-version: 2.6.3
@@ -360,6 +359,7 @@ Signed-off-by: dependabot[bot] <support@github.com>
 - Add pipx installation instructions and update repository metadata in pyproject.toml
   ([`447a75f`](https://github.com/flumi3/markdown-refcheck/commit/447a75fc98c8d9bfee387f4372ffd106d76a7b43))
 
+
 ## v0.4.1 (2025-12-13)
 
 ### Bug Fixes
@@ -371,6 +371,7 @@ Signed-off-by: dependabot[bot] <support@github.com>
 
 - Update badge links and remove outdated coverage badge in README.md
   ([`ca6d611`](https://github.com/flumi3/markdown-refcheck/commit/ca6d611fda0e6cf82047e2bd8e49456c7093860d))
+
 
 ## v0.4.0 (2025-12-13)
 
@@ -390,8 +391,8 @@ Signed-off-by: dependabot[bot] <support@github.com>
 
 - Optimize regex patterns: replace greedy .+ with specific character classes -
   BASIC_REFERENCE_PATTERN: [^\]]+ for text, [^)]+ for links - INLINE_LINK_PATTERN: [^>]+ instead of
-  .+ - Fix \_drop_code_block_references: use list filtering instead of modifying during iteration -
-  Implement \_process_inline_links for processing angle-bracket enclosed links - Activate inline
+  .+ - Fix _drop_code_block_references: use list filtering instead of modifying during iteration -
+  Implement _process_inline_links for processing angle-bracket enclosed links - Activate inline
   links validation in main processing loop - Fix header path resolution: resolve relative markdown
   file paths to absolute before checking for headers (fixes validation of other.md#header patterns)
 
@@ -432,16 +433,16 @@ Signed-off-by: dependabot[bot] <support@github.com>
   ([`f471032`](https://github.com/flumi3/markdown-refcheck/commit/f4710328d8a6ac4664184eec389f3d62ec322626))
 
 Add `open-pull-requests-limit: 0`. This will prevent opening of pull requests for normal version
-bumps. Security updates will still be created.
+  bumps. Security updates will still be created.
 
 - **deps**: Bump requests from 2.32.3 to 2.32.4
   ([#50](https://github.com/flumi3/markdown-refcheck/pull/50),
   [`d2383f4`](https://github.com/flumi3/markdown-refcheck/commit/d2383f4eafdaadadc1fa3d08b00bc5dde25a2408))
 
-Bumps [requests](https://github.com/psf/requests) from 2.32.3 to 2.32.4. -
-[Release notes](https://github.com/psf/requests/releases) -
-[Changelog](https://github.com/psf/requests/blob/main/HISTORY.md) -
-[Commits](https://github.com/psf/requests/compare/v2.32.3...v2.32.4)
+Bumps [requests](https://github.com/psf/requests) from 2.32.3 to 2.32.4. - [Release
+  notes](https://github.com/psf/requests/releases) -
+  [Changelog](https://github.com/psf/requests/blob/main/HISTORY.md) -
+  [Commits](https://github.com/psf/requests/compare/v2.32.3...v2.32.4)
 
 --- updated-dependencies: - dependency-name: requests dependency-version: 2.32.4
 
@@ -481,10 +482,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#37](https://github.com/flumi3/markdown-refcheck/pull/37),
   [`ec4822f`](https://github.com/flumi3/markdown-refcheck/commit/ec4822f65f6c4bf52d49cd02db64b28515eef202))
 
-Bumps [commitizen](https://github.com/commitizen-tools/commitizen) from 4.4.1 to 4.6.1. -
-[Release notes](https://github.com/commitizen-tools/commitizen/releases) -
-[Changelog](https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md) -
-[Commits](https://github.com/commitizen-tools/commitizen/compare/v4.4.1...v4.6.1)
+Bumps [commitizen](https://github.com/commitizen-tools/commitizen) from 4.4.1 to 4.6.1. - [Release
+  notes](https://github.com/commitizen-tools/commitizen/releases) -
+  [Changelog](https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md) -
+  [Commits](https://github.com/commitizen-tools/commitizen/compare/v4.4.1...v4.6.1)
 
 --- updated-dependencies: - dependency-name: commitizen dependency-version: 4.6.1
 
@@ -500,10 +501,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#49](https://github.com/flumi3/markdown-refcheck/pull/49),
   [`4d114b3`](https://github.com/flumi3/markdown-refcheck/commit/4d114b3eefaaa4487c7c78de26dc7e4b9454caf7))
 
-Bumps [commitizen](https://github.com/commitizen-tools/commitizen) from 4.6.1 to 4.8.3. -
-[Release notes](https://github.com/commitizen-tools/commitizen/releases) -
-[Changelog](https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md) -
-[Commits](https://github.com/commitizen-tools/commitizen/compare/v4.6.1...v4.8.3)
+Bumps [commitizen](https://github.com/commitizen-tools/commitizen) from 4.6.1 to 4.8.3. - [Release
+  notes](https://github.com/commitizen-tools/commitizen/releases) -
+  [Changelog](https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md) -
+  [Commits](https://github.com/commitizen-tools/commitizen/compare/v4.6.1...v4.8.3)
 
 --- updated-dependencies: - dependency-name: commitizen dependency-version: 4.8.3
 
@@ -519,10 +520,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#53](https://github.com/flumi3/markdown-refcheck/pull/53),
   [`c94ac98`](https://github.com/flumi3/markdown-refcheck/commit/c94ac98ec6cd58b100f39516ae0302f8233bd813))
 
-Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.3.5 to 8.4.1. -
-[Release notes](https://github.com/pytest-dev/pytest/releases) -
-[Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
-[Commits](https://github.com/pytest-dev/pytest/compare/8.3.5...8.4.1)
+Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.3.5 to 8.4.1. - [Release
+  notes](https://github.com/pytest-dev/pytest/releases) -
+  [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
+  [Commits](https://github.com/pytest-dev/pytest/compare/8.3.5...8.4.1)
 
 --- updated-dependencies: - dependency-name: pytest dependency-version: 8.4.1
 
@@ -538,10 +539,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#69](https://github.com/flumi3/markdown-refcheck/pull/69),
   [`ea9d07c`](https://github.com/flumi3/markdown-refcheck/commit/ea9d07cf232644b578fad26a529d512bb46c1e5a))
 
-Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.4.1 to 8.4.2. -
-[Release notes](https://github.com/pytest-dev/pytest/releases) -
-[Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
-[Commits](https://github.com/pytest-dev/pytest/compare/8.4.1...8.4.2)
+Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.4.1 to 8.4.2. - [Release
+  notes](https://github.com/pytest-dev/pytest/releases) -
+  [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
+  [Commits](https://github.com/pytest-dev/pytest/compare/8.4.1...8.4.2)
 
 --- updated-dependencies: - dependency-name: pytest dependency-version: 8.4.2
 
@@ -558,11 +559,11 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   [`151cf92`](https://github.com/flumi3/markdown-refcheck/commit/151cf929d2f6095bac240c8c5707158b8751a9c6))
 
 Bumps [python-semantic-release](https://github.com/python-semantic-release/python-semantic-release)
-from 10.3.1 to 10.4.1. -
-[Release notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
-[Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
-
-- [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v10.3.1...v10.4.1)
+  from 10.3.1 to 10.4.1. - [Release
+  notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
+  [Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
+  -
+  [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v10.3.1...v10.4.1)
 
 --- updated-dependencies: - dependency-name: python-semantic-release dependency-version: 10.4.1
 
@@ -579,11 +580,11 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   [`b2c89f3`](https://github.com/flumi3/markdown-refcheck/commit/b2c89f3e807ad4d3ef80bb6ae1bb1190d76c5299))
 
 Bumps [python-semantic-release](https://github.com/python-semantic-release/python-semantic-release)
-from 9.21.0 to 9.21.1. -
-[Release notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
-[Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
-
-- [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v9.21...v9.21.1)
+  from 9.21.0 to 9.21.1. - [Release
+  notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
+  [Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
+  -
+  [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v9.21...v9.21.1)
 
 --- updated-dependencies: - dependency-name: python-semantic-release dependency-version: 9.21.1
 
@@ -600,11 +601,11 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   [`4da4e26`](https://github.com/flumi3/markdown-refcheck/commit/4da4e265528e7d54ebc6b6328654ef6e96c0f6a2))
 
 Bumps [python-semantic-release](https://github.com/python-semantic-release/python-semantic-release)
-from 9.21.1 to 10.3.1. -
-[Release notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
-[Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
-
-- [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v9.21.1...v10.3.1)
+  from 9.21.1 to 10.3.1. - [Release
+  notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
+  [Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
+  -
+  [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v9.21.1...v10.3.1)
 
 --- updated-dependencies: - dependency-name: python-semantic-release dependency-version: 10.3.1
 
@@ -620,10 +621,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#36](https://github.com/flumi3/markdown-refcheck/pull/36),
   [`a720223`](https://github.com/flumi3/markdown-refcheck/commit/a7202239bbfeedf251066ccd7cbe07cd415ec476))
 
-Bumps [ruff](https://github.com/astral-sh/ruff) from 0.11.2 to 0.11.8. -
-[Release notes](https://github.com/astral-sh/ruff/releases) -
-[Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md) -
-[Commits](https://github.com/astral-sh/ruff/compare/0.11.2...0.11.8)
+Bumps [ruff](https://github.com/astral-sh/ruff) from 0.11.2 to 0.11.8. - [Release
+  notes](https://github.com/astral-sh/ruff/releases) -
+  [Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md) -
+  [Commits](https://github.com/astral-sh/ruff/compare/0.11.2...0.11.8)
 
 --- updated-dependencies: - dependency-name: ruff dependency-version: 0.11.8
 
@@ -685,7 +686,7 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 
 - Update make init to auto-install pre-commit hooks - Add make bump-version to preview next version
   - Add make changelog to show unreleased changes - Add make check-version to display current/next
-    versions - Add make update-hooks to keep pre-commit hooks current
+  versions - Add make update-hooks to keep pre-commit hooks current
 
 - Configure commitizen and semantic-release for v1.0.0 transition
   ([`9cd0282`](https://github.com/flumi3/markdown-refcheck/commit/9cd02823a414eed8f7e0cccf59c583ead80e6b2f))
@@ -753,7 +754,7 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 
 - Created `tests/conftest.py` with centralized fixtures: - Settings mocks for all flag combinations
   - HTTP request mocks (success, 404, timeout, SSL errors) - File system helpers (temp files,
-    directory structures) - Common test data (sample markdown content)
+  directory structures) - Common test data (sample markdown content)
 
 - Created `tests/fixtures/` directory structure: - `valid/` - Valid markdown with various reference
   types - `code_blocks/` - Code block edge cases - `broken_refs/` - Intentionally broken references
@@ -761,6 +762,7 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 
 - Enhance test coverage configuration and enforce coverage thresholds
   ([`a33f889`](https://github.com/flumi3/markdown-refcheck/commit/a33f889b263eb440ddef3a755de492d2919c3d9b))
+
 
 ## v0.3.0 (2025-03-29)
 
@@ -786,6 +788,7 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 
 - Enable refcheck to be used as pre-commit hook
   ([`39d77ad`](https://github.com/flumi3/markdown-refcheck/commit/39d77adda324e0331c6d5a241158cba1ac846ff5))
+
 
 ## v0.2.0 (2025-03-28)
 
@@ -818,10 +821,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#22](https://github.com/flumi3/markdown-refcheck/pull/22),
   [`70afcca`](https://github.com/flumi3/markdown-refcheck/commit/70afcca83009ba5fd5dbada14eca8ab476832e97))
 
-Bumps [commitizen](https://github.com/commitizen-tools/commitizen) from 4.2.2 to 4.4.1. -
-[Release notes](https://github.com/commitizen-tools/commitizen/releases) -
-[Changelog](https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md) -
-[Commits](https://github.com/commitizen-tools/commitizen/compare/v4.2.2...v4.4.1)
+Bumps [commitizen](https://github.com/commitizen-tools/commitizen) from 4.2.2 to 4.4.1. - [Release
+  notes](https://github.com/commitizen-tools/commitizen/releases) -
+  [Changelog](https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md) -
+  [Commits](https://github.com/commitizen-tools/commitizen/compare/v4.2.2...v4.4.1)
 
 --- updated-dependencies: - dependency-name: commitizen dependency-type: direct:development
 
@@ -835,10 +838,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#23](https://github.com/flumi3/markdown-refcheck/pull/23),
   [`dcd2b38`](https://github.com/flumi3/markdown-refcheck/commit/dcd2b3889137896b292bf04419e0e52a53d9bf19))
 
-Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.3.4 to 8.3.5. -
-[Release notes](https://github.com/pytest-dev/pytest/releases) -
-[Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
-[Commits](https://github.com/pytest-dev/pytest/compare/8.3.4...8.3.5)
+Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.3.4 to 8.3.5. - [Release
+  notes](https://github.com/pytest-dev/pytest/releases) -
+  [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
+  [Commits](https://github.com/pytest-dev/pytest/compare/8.3.4...8.3.5)
 
 --- updated-dependencies: - dependency-name: pytest dependency-type: direct:development
 
@@ -853,14 +856,14 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   [`f1a3ad7`](https://github.com/flumi3/markdown-refcheck/commit/f1a3ad7452916c490c64c819880de572d6415df8))
 
 Bumps [python-semantic-release](https://github.com/python-semantic-release/python-semantic-release)
-from 9.20.0 to 9.21.0. -
-[Release notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
-[Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
-
-- [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v9.20...v9.21)
+  from 9.20.0 to 9.21.0. - [Release
+  notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
+  [Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
+  -
+  [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v9.20...v9.21)
 
 --- updated-dependencies: - dependency-name: python-semantic-release dependency-type:
-direct:development
+  direct:development
 
 update-type: version-update:semver-minor ...
 
@@ -872,10 +875,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#27](https://github.com/flumi3/markdown-refcheck/pull/27),
   [`0913ac6`](https://github.com/flumi3/markdown-refcheck/commit/0913ac6ce5892e0c5d4e446d6040a8c38066e87e))
 
-Bumps [ruff](https://github.com/astral-sh/ruff) from 0.11.0 to 0.11.2. -
-[Release notes](https://github.com/astral-sh/ruff/releases) -
-[Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md) -
-[Commits](https://github.com/astral-sh/ruff/compare/0.11.0...0.11.2)
+Bumps [ruff](https://github.com/astral-sh/ruff) from 0.11.0 to 0.11.2. - [Release
+  notes](https://github.com/astral-sh/ruff/releases) -
+  [Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md) -
+  [Commits](https://github.com/astral-sh/ruff/compare/0.11.0...0.11.2)
 
 --- updated-dependencies: - dependency-name: ruff dependency-type: direct:development
 
@@ -889,10 +892,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#26](https://github.com/flumi3/markdown-refcheck/pull/26),
   [`da9f7a3`](https://github.com/flumi3/markdown-refcheck/commit/da9f7a3e3d71bcf078f5b51db42926e2990bc4dc))
 
-Bumps [ruff](https://github.com/astral-sh/ruff) from 0.9.7 to 0.11.0. -
-[Release notes](https://github.com/astral-sh/ruff/releases) -
-[Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md) -
-[Commits](https://github.com/astral-sh/ruff/compare/0.9.7...0.11.0)
+Bumps [ruff](https://github.com/astral-sh/ruff) from 0.9.7 to 0.11.0. - [Release
+  notes](https://github.com/astral-sh/ruff/releases) -
+  [Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md) -
+  [Commits](https://github.com/astral-sh/ruff/compare/0.9.7...0.11.0)
 
 --- updated-dependencies: - dependency-name: ruff dependency-type: direct:development
 
@@ -959,9 +962,12 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 
 * remove unused import
 
+
 ## v0.1.5 (2025-01-22)
 
+
 ## v0.1.4 (2025-01-17)
+
 
 ## v0.1.3 (2024-11-28)
 
@@ -970,6 +976,7 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 - Markdown file parsing
   ([`a5625f7`](https://github.com/flumi3/markdown-refcheck/commit/a5625f7965aeb271426aca1374de63d9157abddf))
 
+
 ## v0.1.2 (2024-11-27)
 
 ### Bug Fixes
@@ -977,7 +984,7 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 - Release workflow poetry install ([#5](https://github.com/flumi3/markdown-refcheck/pull/5),
   [`e08b80f`](https://github.com/flumi3/markdown-refcheck/commit/e08b80f43035c3d99ec1d31453d96d1e281d535f))
 
-* change workflow name _ fix poetry install _ add tests to flake8 check and resolve issues
+* change workflow name * fix poetry install * add tests to flake8 check and resolve issues
 
 ### Features
 
@@ -988,7 +995,7 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 - Ci workflow ([#3](https://github.com/flumi3/markdown-refcheck/pull/3),
   [`c28e893`](https://github.com/flumi3/markdown-refcheck/commit/c28e893afc6c0fc4e24212097e1fb5431a3f90e4))
 
-* add flake8 _ create ci workflow _ change python version to ^3.9
+* add flake8 * create ci workflow * change python version to ^3.9
 
 - Directories and paths are now specified together
   ([`a391558`](https://github.com/flumi3/markdown-refcheck/commit/a3915586e4ed50b69ab7fd7e7e3793d21776e7d0))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # CHANGELOG
 
-
 ## v0.5.0 (2026-05-22)
 
 ### Features
@@ -12,45 +11,46 @@
 * feat(parsers): add refcheck-ignore comment directives for line/section skipping
 
 Add support for inline markdown comments to skip reference checking: - <!-- refcheck-ignore --> on
-  standalone line: skips next line - <!-- refcheck-ignore --> inline with content: skips that line -
+standalone line: skips next line - <!-- refcheck-ignore --> inline with content: skips that line -
+
   <!-- refcheck-ignore-start --> / <!-- refcheck-ignore-end -->: skips block - All directives
-  support optional reason text - Both <!-- and <!--- syntax supported - Directives inside code
-  blocks are not honored
+
+support optional reason text - Both <!-- and <!--- syntax supported - Directives inside code blocks
+are not honored
 
 Implements #103
 
-* test(parsers): add comprehensive tests for refcheck-ignore directives
+- test(parsers): add comprehensive tests for refcheck-ignore directives
 
 Add TestRefcheckIgnore class with 16 tests covering: - Standalone ignore (next-line), inline ignore
-  (same-line) - Block ignore with start/end directives - Image and inline link filtering - Optional
-  reason text, triple-dash syntax - Ignore directives inside code blocks (not honored) - Unmatched
-  block start (ignore to EOF) - Multiple ignore comments, no over-suppression - Fixture file tests
-  for all scenarios
+(same-line) - Block ignore with start/end directives - Image and inline link filtering - Optional
+reason text, triple-dash syntax - Ignore directives inside code blocks (not honored) - Unmatched
+block start (ignore to EOF) - Multiple ignore comments, no over-suppression - Fixture file tests for
+all scenarios
 
-Also fix _get_ignored_lines to filter against code blocks and inline code only (not HTML comments),
-  since ignore directives are themselves HTML comments.
+Also fix \_get_ignored_lines to filter against code blocks and inline code only (not HTML comments),
+since ignore directives are themselves HTML comments.
 
-* docs(readme): add ignore comments documentation
+- docs(readme): add ignore comments documentation
 
 Document the three refcheck-ignore modes: - Standalone: skip next line - Inline: skip same line -
-  Block: skip entire section - Optional reason text syntax - Note about triple-dash and code block
-  behavior
+Block: skip entire section - Optional reason text syntax - Note about triple-dash and code block
+behavior
 
-* style(parsers): apply ruff formatting
+- style(parsers): apply ruff formatting
 
-* fix(parsers): address review findings for ignore directives
+- fix(parsers): address review findings for ignore directives
 
-- Add optional reason support to refcheck-ignore-end pattern - Make block suppression exclusive of
+* Add optional reason support to refcheck-ignore-end pattern - Make block suppression exclusive of
   start/end marker lines (only lines between markers are suppressed) - Add regression tests for
   end-with-reason and boundary lines - Update README to mention inline code exclusion and standalone
   marker requirement
 
-* docs: move ignore reference docs from README to docs/Ignoring-References.md
+- docs: move ignore reference docs from README to docs/Ignoring-References.md
 
-- Create dedicated docs/Ignoring-References.md with full documentation - Keep only a feature bullet
-  + link in README - Add to documentation listing in README - Fix fixture files that had
-  formatter-injected blank lines
-
+* Create dedicated docs/Ignoring-References.md with full documentation - Keep only a feature bullet
+  - link in README - Add to documentation listing in README - Fix fixture files that had
+    formatter-injected blank lines
 
 ## v0.4.5 (2026-05-22)
 
@@ -63,12 +63,12 @@ Document the three refcheck-ignore modes: - Standalone: skip next line - Inline:
 * chore(deps): bump pytest in the pip group across 1 directory (#105)
 
 Bumps the pip group with 1 update in the / directory:
-  [pytest](https://github.com/pytest-dev/pytest).
+[pytest](https://github.com/pytest-dev/pytest).
 
-Updates `pytest` from 8.4.2 to 9.0.3 - [Release
-  notes](https://github.com/pytest-dev/pytest/releases) -
-  [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
-  [Commits](https://github.com/pytest-dev/pytest/compare/8.4.2...9.0.3)
+Updates `pytest` from 8.4.2 to 9.0.3 -
+[Release notes](https://github.com/pytest-dev/pytest/releases) -
+[Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
+[Commits](https://github.com/pytest-dev/pytest/compare/8.4.2...9.0.3)
 
 --- updated-dependencies: - dependency-name: pytest dependency-version: 9.0.3
 
@@ -76,50 +76,51 @@ dependency-type: direct:development
 
 dependency-group: pip ...
 
-* chore(deps): bump urllib3 in the pip group across 1 directory (#106)
+- chore(deps): bump urllib3 in the pip group across 1 directory (#106)
 
 Bumps the pip group with 1 update in the / directory: [urllib3](https://github.com/urllib3/urllib3).
 
 Updates `urllib3` from 2.6.3 to 2.7.0 - [Release notes](https://github.com/urllib3/urllib3/releases)
-  - [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) -
+
+- [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) -
   [Commits](https://github.com/urllib3/urllib3/compare/2.6.3...2.7.0)
 
 --- updated-dependencies: - dependency-name: urllib3 dependency-version: 2.7.0
 
 dependency-type: indirect
 
-* chore(deps): bump idna in the pip group across 1 directory (#107)
+- chore(deps): bump idna in the pip group across 1 directory (#107)
 
 Bumps the pip group with 1 update in the / directory: [idna](https://github.com/kjd/idna).
 
 Updates `idna` from 3.10 to 3.15 - [Release notes](https://github.com/kjd/idna/releases) -
-  [Changelog](https://github.com/kjd/idna/blob/master/HISTORY.md) -
-  [Commits](https://github.com/kjd/idna/compare/v3.10...v3.15)
+[Changelog](https://github.com/kjd/idna/blob/master/HISTORY.md) -
+[Commits](https://github.com/kjd/idna/compare/v3.10...v3.15)
 
 --- updated-dependencies: - dependency-name: idna dependency-version: '3.15'
 
-* fix(parsers): exclude bare emails from inline link detection
+- fix(parsers): exclude bare emails from inline link detection
 
 Bare email addresses in angle brackets (e.g. <user@example.com>) were matched by INLINE_LINK_PATTERN
-  and flagged as broken local references. Remove the email-matching alternative from the regex so
-  only URLs (http://, https://) and explicit mailto: links are matched.
+and flagged as broken local references. Remove the email-matching alternative from the regex so only
+URLs (http://, https://) and explicit mailto: links are matched.
 
 Closes #108
 
-* chore(tests): update inline links fixture for email handling
+- chore(tests): update inline links fixture for email handling
 
 Update the fixture to reflect that bare emails in angle brackets are not validated as references by
-  refcheck.
+refcheck.
 
-* fix(ci): analyze PR commits for version preview
+- fix(ci): analyze PR commits for version preview
 
 The version preview workflow was using semantic-release which only analyzes commits on the
-  configured release branch (main). In a PR context this meant it never detected version bumps.
+configured release branch (main). In a PR context this meant it never detected version bumps.
 
 Replace with direct commit message analysis of origin/main..HEAD to correctly preview the version
-  bump that would occur after merge.
+bump that would occur after merge.
 
----------
+---
 
 Signed-off-by: dependabot[bot] <support@github.com>
 
@@ -134,8 +135,8 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 Bumps the pip group with 1 update in the / directory: [idna](https://github.com/kjd/idna).
 
 Updates `idna` from 3.10 to 3.15 - [Release notes](https://github.com/kjd/idna/releases) -
-  [Changelog](https://github.com/kjd/idna/blob/master/HISTORY.md) -
-  [Commits](https://github.com/kjd/idna/compare/v3.10...v3.15)
+[Changelog](https://github.com/kjd/idna/blob/master/HISTORY.md) -
+[Commits](https://github.com/kjd/idna/compare/v3.10...v3.15)
 
 --- updated-dependencies: - dependency-name: idna dependency-version: '3.15'
 
@@ -152,12 +153,12 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   [`070c305`](https://github.com/flumi3/markdown-refcheck/commit/070c305f6039dd8dbcbe702421cf4c7649ecde8c))
 
 Bumps the pip group with 1 update in the / directory:
-  [pytest](https://github.com/pytest-dev/pytest).
+[pytest](https://github.com/pytest-dev/pytest).
 
-Updates `pytest` from 8.4.2 to 9.0.3 - [Release
-  notes](https://github.com/pytest-dev/pytest/releases) -
-  [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
-  [Commits](https://github.com/pytest-dev/pytest/compare/8.4.2...9.0.3)
+Updates `pytest` from 8.4.2 to 9.0.3 -
+[Release notes](https://github.com/pytest-dev/pytest/releases) -
+[Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
+[Commits](https://github.com/pytest-dev/pytest/compare/8.4.2...9.0.3)
 
 --- updated-dependencies: - dependency-name: pytest dependency-version: 9.0.3
 
@@ -176,7 +177,8 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 Bumps the pip group with 1 update in the / directory: [urllib3](https://github.com/urllib3/urllib3).
 
 Updates `urllib3` from 2.6.3 to 2.7.0 - [Release notes](https://github.com/urllib3/urllib3/releases)
-  - [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) -
+
+- [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) -
   [Commits](https://github.com/urllib3/urllib3/compare/2.6.3...2.7.0)
 
 --- updated-dependencies: - dependency-name: urllib3 dependency-version: 2.7.0
@@ -189,7 +191,6 @@ Signed-off-by: dependabot[bot] <support@github.com>
 
 Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 
-
 ## v0.4.4 (2026-04-09)
 
 ### Bug Fixes
@@ -200,14 +201,14 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 
 * fix(parsers): ignore references inside HTML comments
 
-* fix(parsers): use position-based filtering in _drop_code_references
+* fix(parsers): use position-based filtering in \_drop_code_references
 
 Replace substring membership check with span comparison to prevent incorrectly dropping references
-  that share the same text as a commented-out or code-block reference at a different position.
+that share the same text as a commented-out or code-block reference at a different position.
 
-* chore: make test case a bit more real
+- chore: make test case a bit more real
 
-* ci(version-preview): pin python-semantic-release to v7
+- ci(version-preview): pin python-semantic-release to v7
 
 ### Chores
 
@@ -216,12 +217,12 @@ Replace substring membership check with span comparison to prevent incorrectly d
   [`ce3e78d`](https://github.com/flumi3/markdown-refcheck/commit/ce3e78df411b41e9891e7053269cf9fb5bc3147f))
 
 Bumps the pip group with 1 update in the / directory:
-  [filelock](https://github.com/tox-dev/py-filelock).
+[filelock](https://github.com/tox-dev/py-filelock).
 
-Updates `filelock` from 3.20.1 to 3.20.3 - [Release
-  notes](https://github.com/tox-dev/py-filelock/releases) -
-  [Changelog](https://github.com/tox-dev/filelock/blob/main/docs/changelog.rst) -
-  [Commits](https://github.com/tox-dev/py-filelock/compare/3.20.1...3.20.3)
+Updates `filelock` from 3.20.1 to 3.20.3 -
+[Release notes](https://github.com/tox-dev/py-filelock/releases) -
+[Changelog](https://github.com/tox-dev/filelock/blob/main/docs/changelog.rst) -
+[Commits](https://github.com/tox-dev/py-filelock/compare/3.20.1...3.20.3)
 
 --- updated-dependencies: - dependency-name: filelock dependency-version: 3.20.3
 
@@ -240,7 +241,8 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 Bumps the pip group with 1 update in the / directory: [requests](https://github.com/psf/requests).
 
 Updates `requests` from 2.32.4 to 2.33.0 - [Release notes](https://github.com/psf/requests/releases)
-  - [Changelog](https://github.com/psf/requests/blob/main/HISTORY.md) -
+
+- [Changelog](https://github.com/psf/requests/blob/main/HISTORY.md) -
   [Commits](https://github.com/psf/requests/compare/v2.32.4...v2.33.0)
 
 --- updated-dependencies: - dependency-name: requests dependency-version: 2.33.0
@@ -252,7 +254,6 @@ dependency-group: pip ...
 Signed-off-by: dependabot[bot] <support@github.com>
 
 Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
-
 
 ## v0.4.3 (2026-03-06)
 
@@ -268,12 +269,12 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([`5709637`](https://github.com/flumi3/markdown-refcheck/commit/5709637b15fe6be2d3f4ddbb13f27c521d35579c))
 
 Bumps the pip group with 1 update in the / directory:
-  [virtualenv](https://github.com/pypa/virtualenv).
+[virtualenv](https://github.com/pypa/virtualenv).
 
-Updates `virtualenv` from 20.33.1 to 20.36.1 - [Release
-  notes](https://github.com/pypa/virtualenv/releases) -
-  [Changelog](https://github.com/pypa/virtualenv/blob/main/docs/changelog.rst) -
-  [Commits](https://github.com/pypa/virtualenv/compare/20.33.1...20.36.1)
+Updates `virtualenv` from 20.33.1 to 20.36.1 -
+[Release notes](https://github.com/pypa/virtualenv/releases) -
+[Changelog](https://github.com/pypa/virtualenv/blob/main/docs/changelog.rst) -
+[Commits](https://github.com/pypa/virtualenv/compare/20.33.1...20.36.1)
 
 --- updated-dependencies: - dependency-name: virtualenv dependency-version: 20.36.1
 
@@ -306,7 +307,6 @@ Signed-off-by: dependabot[bot] <support@github.com>
 - Improve README
   ([`6f93bf6`](https://github.com/flumi3/markdown-refcheck/commit/6f93bf60f76cd6fd8e0819fe7bc835a4459c6dc8))
 
-
 ## v0.4.2 (2026-01-20)
 
 ### Bug Fixes
@@ -322,12 +322,12 @@ This supplements the previous 'fix status codes' commit with proper semantic ver
   ([`818abab`](https://github.com/flumi3/markdown-refcheck/commit/818ababf557795f8c3e7a2ce5f6e1affdc8aabcb))
 
 Bumps the pip group with 1 update in the / directory:
-  [filelock](https://github.com/tox-dev/py-filelock).
+[filelock](https://github.com/tox-dev/py-filelock).
 
-Updates `filelock` from 3.20.0 to 3.20.1 - [Release
-  notes](https://github.com/tox-dev/py-filelock/releases) -
-  [Changelog](https://github.com/tox-dev/filelock/blob/main/docs/changelog.rst) -
-  [Commits](https://github.com/tox-dev/py-filelock/compare/3.20.0...3.20.1)
+Updates `filelock` from 3.20.0 to 3.20.1 -
+[Release notes](https://github.com/tox-dev/py-filelock/releases) -
+[Changelog](https://github.com/tox-dev/filelock/blob/main/docs/changelog.rst) -
+[Commits](https://github.com/tox-dev/py-filelock/compare/3.20.0...3.20.1)
 
 --- updated-dependencies: - dependency-name: filelock dependency-version: 3.20.1
 
@@ -343,7 +343,8 @@ Signed-off-by: dependabot[bot] <support@github.com>
 Bumps the pip group with 1 update in the / directory: [urllib3](https://github.com/urllib3/urllib3).
 
 Updates `urllib3` from 2.6.0 to 2.6.3 - [Release notes](https://github.com/urllib3/urllib3/releases)
-  - [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) -
+
+- [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst) -
   [Commits](https://github.com/urllib3/urllib3/compare/2.6.0...2.6.3)
 
 --- updated-dependencies: - dependency-name: urllib3 dependency-version: 2.6.3
@@ -359,7 +360,6 @@ Signed-off-by: dependabot[bot] <support@github.com>
 - Add pipx installation instructions and update repository metadata in pyproject.toml
   ([`447a75f`](https://github.com/flumi3/markdown-refcheck/commit/447a75fc98c8d9bfee387f4372ffd106d76a7b43))
 
-
 ## v0.4.1 (2025-12-13)
 
 ### Bug Fixes
@@ -371,7 +371,6 @@ Signed-off-by: dependabot[bot] <support@github.com>
 
 - Update badge links and remove outdated coverage badge in README.md
   ([`ca6d611`](https://github.com/flumi3/markdown-refcheck/commit/ca6d611fda0e6cf82047e2bd8e49456c7093860d))
-
 
 ## v0.4.0 (2025-12-13)
 
@@ -391,8 +390,8 @@ Signed-off-by: dependabot[bot] <support@github.com>
 
 - Optimize regex patterns: replace greedy .+ with specific character classes -
   BASIC_REFERENCE_PATTERN: [^\]]+ for text, [^)]+ for links - INLINE_LINK_PATTERN: [^>]+ instead of
-  .+ - Fix _drop_code_block_references: use list filtering instead of modifying during iteration -
-  Implement _process_inline_links for processing angle-bracket enclosed links - Activate inline
+  .+ - Fix \_drop_code_block_references: use list filtering instead of modifying during iteration -
+  Implement \_process_inline_links for processing angle-bracket enclosed links - Activate inline
   links validation in main processing loop - Fix header path resolution: resolve relative markdown
   file paths to absolute before checking for headers (fixes validation of other.md#header patterns)
 
@@ -433,16 +432,16 @@ Signed-off-by: dependabot[bot] <support@github.com>
   ([`f471032`](https://github.com/flumi3/markdown-refcheck/commit/f4710328d8a6ac4664184eec389f3d62ec322626))
 
 Add `open-pull-requests-limit: 0`. This will prevent opening of pull requests for normal version
-  bumps. Security updates will still be created.
+bumps. Security updates will still be created.
 
 - **deps**: Bump requests from 2.32.3 to 2.32.4
   ([#50](https://github.com/flumi3/markdown-refcheck/pull/50),
   [`d2383f4`](https://github.com/flumi3/markdown-refcheck/commit/d2383f4eafdaadadc1fa3d08b00bc5dde25a2408))
 
-Bumps [requests](https://github.com/psf/requests) from 2.32.3 to 2.32.4. - [Release
-  notes](https://github.com/psf/requests/releases) -
-  [Changelog](https://github.com/psf/requests/blob/main/HISTORY.md) -
-  [Commits](https://github.com/psf/requests/compare/v2.32.3...v2.32.4)
+Bumps [requests](https://github.com/psf/requests) from 2.32.3 to 2.32.4. -
+[Release notes](https://github.com/psf/requests/releases) -
+[Changelog](https://github.com/psf/requests/blob/main/HISTORY.md) -
+[Commits](https://github.com/psf/requests/compare/v2.32.3...v2.32.4)
 
 --- updated-dependencies: - dependency-name: requests dependency-version: 2.32.4
 
@@ -482,10 +481,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#37](https://github.com/flumi3/markdown-refcheck/pull/37),
   [`ec4822f`](https://github.com/flumi3/markdown-refcheck/commit/ec4822f65f6c4bf52d49cd02db64b28515eef202))
 
-Bumps [commitizen](https://github.com/commitizen-tools/commitizen) from 4.4.1 to 4.6.1. - [Release
-  notes](https://github.com/commitizen-tools/commitizen/releases) -
-  [Changelog](https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md) -
-  [Commits](https://github.com/commitizen-tools/commitizen/compare/v4.4.1...v4.6.1)
+Bumps [commitizen](https://github.com/commitizen-tools/commitizen) from 4.4.1 to 4.6.1. -
+[Release notes](https://github.com/commitizen-tools/commitizen/releases) -
+[Changelog](https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md) -
+[Commits](https://github.com/commitizen-tools/commitizen/compare/v4.4.1...v4.6.1)
 
 --- updated-dependencies: - dependency-name: commitizen dependency-version: 4.6.1
 
@@ -501,10 +500,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#49](https://github.com/flumi3/markdown-refcheck/pull/49),
   [`4d114b3`](https://github.com/flumi3/markdown-refcheck/commit/4d114b3eefaaa4487c7c78de26dc7e4b9454caf7))
 
-Bumps [commitizen](https://github.com/commitizen-tools/commitizen) from 4.6.1 to 4.8.3. - [Release
-  notes](https://github.com/commitizen-tools/commitizen/releases) -
-  [Changelog](https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md) -
-  [Commits](https://github.com/commitizen-tools/commitizen/compare/v4.6.1...v4.8.3)
+Bumps [commitizen](https://github.com/commitizen-tools/commitizen) from 4.6.1 to 4.8.3. -
+[Release notes](https://github.com/commitizen-tools/commitizen/releases) -
+[Changelog](https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md) -
+[Commits](https://github.com/commitizen-tools/commitizen/compare/v4.6.1...v4.8.3)
 
 --- updated-dependencies: - dependency-name: commitizen dependency-version: 4.8.3
 
@@ -520,10 +519,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#53](https://github.com/flumi3/markdown-refcheck/pull/53),
   [`c94ac98`](https://github.com/flumi3/markdown-refcheck/commit/c94ac98ec6cd58b100f39516ae0302f8233bd813))
 
-Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.3.5 to 8.4.1. - [Release
-  notes](https://github.com/pytest-dev/pytest/releases) -
-  [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
-  [Commits](https://github.com/pytest-dev/pytest/compare/8.3.5...8.4.1)
+Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.3.5 to 8.4.1. -
+[Release notes](https://github.com/pytest-dev/pytest/releases) -
+[Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
+[Commits](https://github.com/pytest-dev/pytest/compare/8.3.5...8.4.1)
 
 --- updated-dependencies: - dependency-name: pytest dependency-version: 8.4.1
 
@@ -539,10 +538,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#69](https://github.com/flumi3/markdown-refcheck/pull/69),
   [`ea9d07c`](https://github.com/flumi3/markdown-refcheck/commit/ea9d07cf232644b578fad26a529d512bb46c1e5a))
 
-Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.4.1 to 8.4.2. - [Release
-  notes](https://github.com/pytest-dev/pytest/releases) -
-  [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
-  [Commits](https://github.com/pytest-dev/pytest/compare/8.4.1...8.4.2)
+Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.4.1 to 8.4.2. -
+[Release notes](https://github.com/pytest-dev/pytest/releases) -
+[Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
+[Commits](https://github.com/pytest-dev/pytest/compare/8.4.1...8.4.2)
 
 --- updated-dependencies: - dependency-name: pytest dependency-version: 8.4.2
 
@@ -559,11 +558,11 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   [`151cf92`](https://github.com/flumi3/markdown-refcheck/commit/151cf929d2f6095bac240c8c5707158b8751a9c6))
 
 Bumps [python-semantic-release](https://github.com/python-semantic-release/python-semantic-release)
-  from 10.3.1 to 10.4.1. - [Release
-  notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
-  [Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
-  -
-  [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v10.3.1...v10.4.1)
+from 10.3.1 to 10.4.1. -
+[Release notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
+[Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
+
+- [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v10.3.1...v10.4.1)
 
 --- updated-dependencies: - dependency-name: python-semantic-release dependency-version: 10.4.1
 
@@ -580,11 +579,11 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   [`b2c89f3`](https://github.com/flumi3/markdown-refcheck/commit/b2c89f3e807ad4d3ef80bb6ae1bb1190d76c5299))
 
 Bumps [python-semantic-release](https://github.com/python-semantic-release/python-semantic-release)
-  from 9.21.0 to 9.21.1. - [Release
-  notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
-  [Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
-  -
-  [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v9.21...v9.21.1)
+from 9.21.0 to 9.21.1. -
+[Release notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
+[Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
+
+- [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v9.21...v9.21.1)
 
 --- updated-dependencies: - dependency-name: python-semantic-release dependency-version: 9.21.1
 
@@ -601,11 +600,11 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   [`4da4e26`](https://github.com/flumi3/markdown-refcheck/commit/4da4e265528e7d54ebc6b6328654ef6e96c0f6a2))
 
 Bumps [python-semantic-release](https://github.com/python-semantic-release/python-semantic-release)
-  from 9.21.1 to 10.3.1. - [Release
-  notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
-  [Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
-  -
-  [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v9.21.1...v10.3.1)
+from 9.21.1 to 10.3.1. -
+[Release notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
+[Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
+
+- [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v9.21.1...v10.3.1)
 
 --- updated-dependencies: - dependency-name: python-semantic-release dependency-version: 10.3.1
 
@@ -621,10 +620,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#36](https://github.com/flumi3/markdown-refcheck/pull/36),
   [`a720223`](https://github.com/flumi3/markdown-refcheck/commit/a7202239bbfeedf251066ccd7cbe07cd415ec476))
 
-Bumps [ruff](https://github.com/astral-sh/ruff) from 0.11.2 to 0.11.8. - [Release
-  notes](https://github.com/astral-sh/ruff/releases) -
-  [Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md) -
-  [Commits](https://github.com/astral-sh/ruff/compare/0.11.2...0.11.8)
+Bumps [ruff](https://github.com/astral-sh/ruff) from 0.11.2 to 0.11.8. -
+[Release notes](https://github.com/astral-sh/ruff/releases) -
+[Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md) -
+[Commits](https://github.com/astral-sh/ruff/compare/0.11.2...0.11.8)
 
 --- updated-dependencies: - dependency-name: ruff dependency-version: 0.11.8
 
@@ -686,7 +685,7 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 
 - Update make init to auto-install pre-commit hooks - Add make bump-version to preview next version
   - Add make changelog to show unreleased changes - Add make check-version to display current/next
-  versions - Add make update-hooks to keep pre-commit hooks current
+    versions - Add make update-hooks to keep pre-commit hooks current
 
 - Configure commitizen and semantic-release for v1.0.0 transition
   ([`9cd0282`](https://github.com/flumi3/markdown-refcheck/commit/9cd02823a414eed8f7e0cccf59c583ead80e6b2f))
@@ -754,7 +753,7 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 
 - Created `tests/conftest.py` with centralized fixtures: - Settings mocks for all flag combinations
   - HTTP request mocks (success, 404, timeout, SSL errors) - File system helpers (temp files,
-  directory structures) - Common test data (sample markdown content)
+    directory structures) - Common test data (sample markdown content)
 
 - Created `tests/fixtures/` directory structure: - `valid/` - Valid markdown with various reference
   types - `code_blocks/` - Code block edge cases - `broken_refs/` - Intentionally broken references
@@ -762,7 +761,6 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 
 - Enhance test coverage configuration and enforce coverage thresholds
   ([`a33f889`](https://github.com/flumi3/markdown-refcheck/commit/a33f889b263eb440ddef3a755de492d2919c3d9b))
-
 
 ## v0.3.0 (2025-03-29)
 
@@ -788,7 +786,6 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 
 - Enable refcheck to be used as pre-commit hook
   ([`39d77ad`](https://github.com/flumi3/markdown-refcheck/commit/39d77adda324e0331c6d5a241158cba1ac846ff5))
-
 
 ## v0.2.0 (2025-03-28)
 
@@ -821,10 +818,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#22](https://github.com/flumi3/markdown-refcheck/pull/22),
   [`70afcca`](https://github.com/flumi3/markdown-refcheck/commit/70afcca83009ba5fd5dbada14eca8ab476832e97))
 
-Bumps [commitizen](https://github.com/commitizen-tools/commitizen) from 4.2.2 to 4.4.1. - [Release
-  notes](https://github.com/commitizen-tools/commitizen/releases) -
-  [Changelog](https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md) -
-  [Commits](https://github.com/commitizen-tools/commitizen/compare/v4.2.2...v4.4.1)
+Bumps [commitizen](https://github.com/commitizen-tools/commitizen) from 4.2.2 to 4.4.1. -
+[Release notes](https://github.com/commitizen-tools/commitizen/releases) -
+[Changelog](https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md) -
+[Commits](https://github.com/commitizen-tools/commitizen/compare/v4.2.2...v4.4.1)
 
 --- updated-dependencies: - dependency-name: commitizen dependency-type: direct:development
 
@@ -838,10 +835,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#23](https://github.com/flumi3/markdown-refcheck/pull/23),
   [`dcd2b38`](https://github.com/flumi3/markdown-refcheck/commit/dcd2b3889137896b292bf04419e0e52a53d9bf19))
 
-Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.3.4 to 8.3.5. - [Release
-  notes](https://github.com/pytest-dev/pytest/releases) -
-  [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
-  [Commits](https://github.com/pytest-dev/pytest/compare/8.3.4...8.3.5)
+Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.3.4 to 8.3.5. -
+[Release notes](https://github.com/pytest-dev/pytest/releases) -
+[Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst) -
+[Commits](https://github.com/pytest-dev/pytest/compare/8.3.4...8.3.5)
 
 --- updated-dependencies: - dependency-name: pytest dependency-type: direct:development
 
@@ -856,14 +853,14 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   [`f1a3ad7`](https://github.com/flumi3/markdown-refcheck/commit/f1a3ad7452916c490c64c819880de572d6415df8))
 
 Bumps [python-semantic-release](https://github.com/python-semantic-release/python-semantic-release)
-  from 9.20.0 to 9.21.0. - [Release
-  notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
-  [Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
-  -
-  [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v9.20...v9.21)
+from 9.20.0 to 9.21.0. -
+[Release notes](https://github.com/python-semantic-release/python-semantic-release/releases) -
+[Changelog](https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.rst)
+
+- [Commits](https://github.com/python-semantic-release/python-semantic-release/compare/v9.20...v9.21)
 
 --- updated-dependencies: - dependency-name: python-semantic-release dependency-type:
-  direct:development
+direct:development
 
 update-type: version-update:semver-minor ...
 
@@ -875,10 +872,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#27](https://github.com/flumi3/markdown-refcheck/pull/27),
   [`0913ac6`](https://github.com/flumi3/markdown-refcheck/commit/0913ac6ce5892e0c5d4e446d6040a8c38066e87e))
 
-Bumps [ruff](https://github.com/astral-sh/ruff) from 0.11.0 to 0.11.2. - [Release
-  notes](https://github.com/astral-sh/ruff/releases) -
-  [Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md) -
-  [Commits](https://github.com/astral-sh/ruff/compare/0.11.0...0.11.2)
+Bumps [ruff](https://github.com/astral-sh/ruff) from 0.11.0 to 0.11.2. -
+[Release notes](https://github.com/astral-sh/ruff/releases) -
+[Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md) -
+[Commits](https://github.com/astral-sh/ruff/compare/0.11.0...0.11.2)
 
 --- updated-dependencies: - dependency-name: ruff dependency-type: direct:development
 
@@ -892,10 +889,10 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
   ([#26](https://github.com/flumi3/markdown-refcheck/pull/26),
   [`da9f7a3`](https://github.com/flumi3/markdown-refcheck/commit/da9f7a3e3d71bcf078f5b51db42926e2990bc4dc))
 
-Bumps [ruff](https://github.com/astral-sh/ruff) from 0.9.7 to 0.11.0. - [Release
-  notes](https://github.com/astral-sh/ruff/releases) -
-  [Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md) -
-  [Commits](https://github.com/astral-sh/ruff/compare/0.9.7...0.11.0)
+Bumps [ruff](https://github.com/astral-sh/ruff) from 0.9.7 to 0.11.0. -
+[Release notes](https://github.com/astral-sh/ruff/releases) -
+[Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md) -
+[Commits](https://github.com/astral-sh/ruff/compare/0.9.7...0.11.0)
 
 --- updated-dependencies: - dependency-name: ruff dependency-type: direct:development
 
@@ -962,12 +959,9 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 
 * remove unused import
 
-
 ## v0.1.5 (2025-01-22)
 
-
 ## v0.1.4 (2025-01-17)
-
 
 ## v0.1.3 (2024-11-28)
 
@@ -976,7 +970,6 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 - Markdown file parsing
   ([`a5625f7`](https://github.com/flumi3/markdown-refcheck/commit/a5625f7965aeb271426aca1374de63d9157abddf))
 
-
 ## v0.1.2 (2024-11-27)
 
 ### Bug Fixes
@@ -984,7 +977,7 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 - Release workflow poetry install ([#5](https://github.com/flumi3/markdown-refcheck/pull/5),
   [`e08b80f`](https://github.com/flumi3/markdown-refcheck/commit/e08b80f43035c3d99ec1d31453d96d1e281d535f))
 
-* change workflow name * fix poetry install * add tests to flake8 check and resolve issues
+* change workflow name _ fix poetry install _ add tests to flake8 check and resolve issues
 
 ### Features
 
@@ -995,7 +988,7 @@ Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.c
 - Ci workflow ([#3](https://github.com/flumi3/markdown-refcheck/pull/3),
   [`c28e893`](https://github.com/flumi3/markdown-refcheck/commit/c28e893afc6c0fc4e24212097e1fb5431a3f90e4))
 
-* add flake8 * create ci workflow * change python version to ^3.9
+* add flake8 _ create ci workflow _ change python version to ^3.9
 
 - Directories and paths are now specified together
   ([`a391558`](https://github.com/flumi3/markdown-refcheck/commit/a3915586e4ed50b69ab7fd7e7e3793d21776e7d0))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ For detailed setup instructions, architecture, and conventions, see the
 
 ## Reporting Bugs
 
-Create an issue with: steps to reproduce, expected vs. actual behavior, your environment (OS, Python version, RefCheck
-version), and sample Markdown files if applicable.
+Create an issue with: steps to reproduce, expected vs. actual behavior, your environment (OS, Python
+version, RefCheck version), and sample Markdown files if applicable.
 
 ## Suggesting Features
 
@@ -16,8 +16,10 @@ Check existing issues first, then describe the feature, its benefits, and usage 
 
 ## Pull Request Workflow
 
-1. Fork the repo and create a branch from `main` (e.g., `feat/add-json-output`, `fix/handle-empty-files`)
-2. Set up the dev environment: `make init` (see [Development Guide](docs/developer-guide/Development-Guide.md#setup))
+1. Fork the repo and create a branch from `main` (e.g., `feat/add-json-output`,
+   `fix/handle-empty-files`)
+2. Set up the dev environment: `make init` (see
+   [Development Guide](docs/developer-guide/Development-Guide.md#setup))
 3. Make your changes and add tests for new functionality
 4. Run `make qa` and `make test` — all checks must pass
 5. Commit using [conventional commits](#commit-convention)
@@ -25,8 +27,8 @@ Check existing issues first, then describe the feature, its benefits, and usage 
 
 ## Commit Convention
 
-This project uses [Conventional Commits](https://www.conventionalcommits.org/) for automated versioning and changelog
-generation. Pre-commit hooks enforce the format.
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) for automated
+versioning and changelog generation. Pre-commit hooks enforce the format.
 
 ```text
 <type>(<scope>): <description>
@@ -34,14 +36,15 @@ generation. Pre-commit hooks enforce the format.
 
 **Types that trigger releases:**
 
-| Type | Release |
-|------|---------|
-| `feat:` | Minor (0.1.0 → 0.2.0) |
-| `fix:` | Patch (0.1.0 → 0.1.1) |
-| `perf:` | Patch |
+| Type                     | Release               |
+| ------------------------ | --------------------- |
+| `feat:`                  | Minor (0.1.0 → 0.2.0) |
+| `fix:`                   | Patch (0.1.0 → 0.1.1) |
+| `perf:`                  | Patch                 |
 | `BREAKING CHANGE:` / `!` | Major (0.1.0 → 1.0.0) |
 
-**Types that don't trigger releases:** `docs:`, `chore:`, `ci:`, `style:`, `refactor:`, `test:`, `build:`
+**Types that don't trigger releases:** `docs:`, `chore:`, `ci:`, `style:`, `refactor:`, `test:`,
+`build:`
 
 **Examples:**
 

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ help: ## Display this help message
 init: ## Initialize the development environment for all modules
 	@echo "$(COLOR_BLUE_BG)$(COLOR_BOLD) ➜ Initializing Core Environment $(COLOR_RESET)"
 	@poetry sync
+	@echo "$(COLOR_BLUE_BG)$(COLOR_BOLD) ➜ Installing docs QA tooling $(COLOR_RESET)"
+	@npm install
 	@echo "$(COLOR_BLUE_BG)$(COLOR_BOLD) ➜ Installing pre-commit hooks $(COLOR_RESET)"
 	@poetry run pre-commit install --hook-type commit-msg --hook-type pre-push
 	@echo "$(COLOR_GREEN) ✔ Done$(COLOR_RESET)"
@@ -94,6 +96,44 @@ qa: format lint check-types check-dead-code check-unused-deps ## Run all quality
 
 .PHONY: ci-qa
 ci-qa: format-check lint-check check-types check-dead-code check-unused-deps ## Run all quality assurance checks for CI (non-modifying)
+
+# --- Docs QA ---
+
+.PHONY: docs-format
+docs-format: ## Format Markdown files with Prettier
+	@echo "$(COLOR_BLUE_BG)$(COLOR_BOLD) ➜ Formatting Markdown with Prettier $(COLOR_RESET)"
+	@npx prettier --write "**/*.md"
+	@echo "$(COLOR_GREEN) ✔ Done$(COLOR_RESET)"
+
+.PHONY: docs-format-check
+docs-format-check: ## Check Markdown formatting without modifying files
+	@echo "$(COLOR_BLUE_BG)$(COLOR_BOLD) ➜ Checking Markdown formatting with Prettier $(COLOR_RESET)"
+	@npx prettier --check "**/*.md"
+	@echo "$(COLOR_GREEN) ✔ Done$(COLOR_RESET)"
+
+.PHONY: docs-lint
+docs-lint: ## Lint Markdown files with markdownlint
+	@echo "$(COLOR_BLUE_BG)$(COLOR_BOLD) ➜ Linting Markdown with markdownlint $(COLOR_RESET)"
+	@npx markdownlint --fix "**/*.md"
+	@echo "$(COLOR_GREEN) ✔ Done$(COLOR_RESET)"
+
+.PHONY: docs-lint-check
+docs-lint-check: ## Check Markdown linting without modifying files
+	@echo "$(COLOR_BLUE_BG)$(COLOR_BOLD) ➜ Checking Markdown linting with markdownlint $(COLOR_RESET)"
+	@npx markdownlint "**/*.md"
+	@echo "$(COLOR_GREEN) ✔ Done$(COLOR_RESET)"
+
+.PHONY: docs-refcheck
+docs-refcheck: ## Check for broken references in Markdown files
+	@echo "$(COLOR_BLUE_BG)$(COLOR_BOLD) ➜ Checking references with refcheck $(COLOR_RESET)"
+	@poetry run refcheck .
+	@echo "$(COLOR_GREEN) ✔ Done$(COLOR_RESET)"
+
+.PHONY: docs-qa
+docs-qa: docs-format docs-lint docs-refcheck ## Run all docs QA checks (auto-fix)
+
+.PHONY: docs-qa-check
+docs-qa-check: docs-format-check docs-lint-check docs-refcheck ## Run all docs QA checks for CI (non-modifying)
 
 # --- Tests ---
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-silver.svg)](https://opensource.org/licenses/MIT)
 [![CI/CD](https://github.com/flumi3/markdown-refcheck/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/flumi3/markdown-refcheck/actions/workflows/ci-cd.yml)
 
-Markdown RefCheck is a simple tool that checks Markdown references to find any broken links. It helps keeping your
-documentation free from broken section refs, missing images and files, and unavailable website links.
+Markdown RefCheck is a simple tool that checks Markdown references to find any broken links. It
+helps keeping your documentation free from broken section refs, missing images and files, and
+unavailable website links.
 
 ## Features
 
@@ -15,7 +16,8 @@ documentation free from broken section refs, missing images and files, and unava
 - 💬 **Inline Ignore Comments** — Suppress false positives with
   [`<!-- refcheck-ignore -->`](docs/user-guide/Ignoring-References.md) directives
 - ⚙️ **CI/CD Ready** — Exit codes and `--no-color` for automation
-- 🚀 **Pre-commit Integration** — Available as a [pre-commit hook](docs/user-guide/Integration-Guide.md#pre-commit-hook)
+- 🚀 **Pre-commit Integration** — Available as a
+  [pre-commit hook](docs/user-guide/Integration-Guide.md#pre-commit-hook)
 
 ## Installation
 
@@ -71,13 +73,15 @@ For all CLI options, see the [CLI Reference](docs/user-guide/CLI-Reference.md).
       args: ["docs/", "--exclude", "docs/filetoexclude.md"]
 ```
 
-See the [Integration Guide](docs/user-guide/Integration-Guide.md) for CI/CD and other workflow setups.
+See the [Integration Guide](docs/user-guide/Integration-Guide.md) for CI/CD and other workflow
+setups.
 
 ## Documentation
 
 - [CLI Reference](docs/user-guide/CLI-Reference.md) — Command-line options
 - [Ignoring References](docs/user-guide/Ignoring-References.md) — Suppress false positives
-- [Integration Guide](docs/user-guide/Integration-Guide.md) — Pre-commit, CI/CD, Azure DevOps, Makefile
+- [Integration Guide](docs/user-guide/Integration-Guide.md) — Pre-commit, CI/CD, Azure DevOps,
+  Makefile
 - [Development Guide](docs/developer-guide/Development-Guide.md) — Architecture, setup, conventions
 
 ## Contributing

--- a/docs/developer-guide/Development-Guide.md
+++ b/docs/developer-guide/Development-Guide.md
@@ -34,26 +34,29 @@ make help            # Show all available commands
 ### Core Pipeline
 
 1. **CLI** → `argparse` in `cli.py`, exposed as singleton `settings` in `settings.py`
-2. **File Discovery** → `get_markdown_files_from_args()` in `utils.py` collects `.md` files respecting `--exclude`
+2. **File Discovery** → `get_markdown_files_from_args()` in `utils.py` collects `.md` files
+   respecting `--exclude`
 3. **Parsing** → `MarkdownParser` extracts references using regex patterns, filters out code blocks
 4. **Validation** → `ReferenceChecker` validates each reference (local files, headers, remote URLs)
 5. **Reporting** → Aggregates broken refs, prints summary with colored output
 
 ### Key Components
 
-- **`parsers.py`** — Regex-based extraction of references. Code blocks/inline code are extracted first to filter false
-  positives. Returns dict with keys: `basic_references`, `basic_images`, `inline_links`.
+- **`parsers.py`** — Regex-based extraction of references. Code blocks/inline code are extracted
+  first to filter false positives. Returns dict with keys: `basic_references`, `basic_images`,
+  `inline_links`.
 - **`validators.py`** — `file_exists()` handles relative, Windows backslash, and absolute paths.
-  `is_valid_markdown_reference()` validates `.md` files and header anchors. Remote checks use `requests.head()` with 5s
-  timeout.
-- **`settings.py`** — Properties only (no setters), initialized once from CLI args. Returns empty defaults when running
-  under pytest.
+  `is_valid_markdown_reference()` validates `.md` files and header anchors. Remote checks use
+  `requests.head()` with 5s timeout.
+- **`settings.py`** — Properties only (no setters), initialized once from CLI args. Returns empty
+  defaults when running under pytest.
 
 ## Project Conventions
 
 - **Path handling**: `os.path` (not `pathlib`), normalize with `os.path.abspath()`
 - **Logging**: Module-level `logger = logging.getLogger()`, setup via `log_conf.py`
-- **Color output**: `print_red()`, `print_green()`, `print_yellow()` in `utils.py` — respect `settings.no_color`
+- **Color output**: `print_red()`, `print_green()`, `print_yellow()` in `utils.py` — respect
+  `settings.no_color`
 - **Regex patterns**: Defined at module level as compiled patterns
 - **Error handling**: Broad try-except for file I/O, `requests.exceptions.RequestException` for HTTP
 
@@ -74,20 +77,21 @@ poetry run pytest -k "test_header"
 
 ## Tooling
 
-| Tool | Purpose | Config |
-|------|---------|--------|
-| **Poetry** | Package management | `pyproject.toml` |
-| **Ruff** | Format + lint | Line length: 100 |
-| **MyPy** | Type checking | `disallow_untyped_defs = false` |
-| **Vulture** | Dead code detection | Min confidence: 80 |
-| **Deptry** | Unused dependency detection | — |
+| Tool        | Purpose                     | Config                          |
+| ----------- | --------------------------- | ------------------------------- |
+| **Poetry**  | Package management          | `pyproject.toml`                |
+| **Ruff**    | Format + lint               | Line length: 100                |
+| **MyPy**    | Type checking               | `disallow_untyped_defs = false` |
+| **Vulture** | Dead code detection         | Min confidence: 80              |
+| **Deptry**  | Unused dependency detection | —                               |
 
 ## Release Process
 
 Automated via GitHub Actions on push to `main`:
 
 1. `python-semantic-release` analyzes commit messages
-2. Version bumped based on commit types (see [CONTRIBUTING.md](../../CONTRIBUTING.md#commit-convention))
+2. Version bumped based on commit types (see
+   [CONTRIBUTING.md](../../CONTRIBUTING.md#commit-convention))
 3. `CHANGELOG.md` updated, git tag created
 4. Package built and published to PyPI
 
@@ -95,10 +99,11 @@ Version tracked in: `pyproject.toml`, `README.md` (pre-commit hook ref).
 
 ## Common Gotchas
 
-1. **Absolute paths**: `/file.md` is NOT treated as root unless `--allow-absolute` is set — it searches up the
-   directory tree from the origin file.
+1. **Absolute paths**: `/file.md` is NOT treated as root unless `--allow-absolute` is set — it
+   searches up the directory tree from the origin file.
 2. **Windows backslash**: `\file.md` is treated as relative (leading backslash removed).
-3. **Code block filtering**: References inside ` ```...``` ` or `` `...` `` are intentionally ignored.
+3. **Code block filtering**: References inside ` ```...``` ` or `` `...` `` are intentionally
+   ignored.
 4. **Remote checks**: Default OFF — must use `--check-remote` flag.
 5. **Settings in tests**: Settings object returns empty defaults when pytest is running.
 

--- a/docs/user-guide/CLI-Reference.md
+++ b/docs/user-guide/CLI-Reference.md
@@ -6,27 +6,27 @@ refcheck [OPTIONS] [PATH ...]
 
 ## Arguments
 
-| Argument | Description |
-|----------|-------------|
-| `PATH` | One or more Markdown files or directories to check. Directories are searched recursively for `.md` files. |
+| Argument | Description                                                                                               |
+| -------- | --------------------------------------------------------------------------------------------------------- |
+| `PATH`   | One or more Markdown files or directories to check. Directories are searched recursively for `.md` files. |
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| `-h`, `--help` | Show help message and exit. |
-| `-e`, `--exclude [...]` | Exclude files or directories from checking. |
-| `-cm`, `--check-remote` | Validate remote HTTP/HTTPS URLs (skipped by default). Uses HEAD requests with a 5s timeout. |
-| `-nc`, `--no-color` | Disable colored output. Useful for CI/CD or redirecting to files. |
-| `-v`, `--verbose` | Enable verbose logging (file parsing details, validation steps, HTTP info). |
-| `--allow-absolute` | Allow absolute path references like `/docs/file.md`. Without this flag, absolute paths are flagged as broken. |
+| Option                  | Description                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `-h`, `--help`          | Show help message and exit.                                                                                   |
+| `-e`, `--exclude [...]` | Exclude files or directories from checking.                                                                   |
+| `-cm`, `--check-remote` | Validate remote HTTP/HTTPS URLs (skipped by default). Uses HEAD requests with a 5s timeout.                   |
+| `-nc`, `--no-color`     | Disable colored output. Useful for CI/CD or redirecting to files.                                             |
+| `-v`, `--verbose`       | Enable verbose logging (file parsing details, validation steps, HTTP info).                                   |
+| `--allow-absolute`      | Allow absolute path references like `/docs/file.md`. Without this flag, absolute paths are flagged as broken. |
 
 ## Exit Codes
 
-| Code | Meaning |
-|------|---------|
-| `0` | No broken references found. |
-| `1` | Broken references detected or invalid arguments. |
+| Code | Meaning                                          |
+| ---- | ------------------------------------------------ |
+| `0`  | No broken references found.                      |
+| `1`  | Broken references detected or invalid arguments. |
 
 ## Examples
 

--- a/docs/user-guide/Ignoring-References.md
+++ b/docs/user-guide/Ignoring-References.md
@@ -1,7 +1,8 @@
 # Ignoring References
 
-RefCheck supports HTML comment directives to suppress reference checking on specific lines or sections. This is useful
-for handling false positives or references that are intentionally broken (e.g., placeholder links, VPN-only URLs).
+RefCheck supports HTML comment directives to suppress reference checking on specific lines or
+sections. This is useful for handling false positives or references that are intentionally broken
+(e.g., placeholder links, VPN-only URLs).
 
 ## Table of Contents
 
@@ -16,6 +17,7 @@ Place the comment on its own line to skip the reference on the **next** line:
 
 ```markdown
 <!-- refcheck-ignore -->
+
 [This reference will not be checked](./some/path.md)
 ```
 
@@ -31,8 +33,9 @@ Wrap a block of lines with start/end directives to skip all references within:
 
 ```markdown
 <!-- refcheck-ignore-start -->
-[ignored](./a.md)
-[also ignored](./b.md)
+
+[ignored](./a.md) [also ignored](./b.md)
+
 <!-- refcheck-ignore-end -->
 ```
 
@@ -40,16 +43,18 @@ References before and after the block are still checked as normal.
 
 ## Optional Reason
 
-All directives accept an optional reason after a colon. This is purely for documentation purposes and does not affect
-behavior:
+All directives accept an optional reason after a colon. This is purely for documentation purposes
+and does not affect behavior:
 
 ```markdown
 <!-- refcheck-ignore: external link only available on VPN -->
+
 [internal docs](https://internal.example.com/docs)
 
 <!-- refcheck-ignore-start: placeholder links for upcoming feature -->
-[feature docs](./upcoming/feature.md)
-[feature API](./upcoming/api.md)
+
+[feature docs](./upcoming/feature.md) [feature API](./upcoming/api.md)
+
 <!-- refcheck-ignore-end: placeholder links for upcoming feature -->
 ```
 

--- a/docs/user-guide/Integration-Guide.md
+++ b/docs/user-guide/Integration-Guide.md
@@ -131,9 +131,9 @@ steps:
 ```makefile
 .PHONY: check-docs
 check-docs:
-	@refcheck docs/ README.md --no-color
+ @refcheck docs/ README.md --no-color
 
 .PHONY: check-docs-full
 check-docs-full:
-	@refcheck docs/ README.md --check-remote --no-color
+ @refcheck docs/ README.md --check-remote --no-color
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1179 @@
+{
+  "name": "refcheck-docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "refcheck-docs",
+      "devDependencies": {
+        "markdownlint-cli": "0.48.0",
+        "prettier": "3.8.1"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
+      "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark": "4.0.2",
+        "micromark-core-commonmark": "2.0.3",
+        "micromark-extension-directive": "4.0.0",
+        "micromark-extension-gfm-autolink-literal": "2.1.0",
+        "micromark-extension-gfm-footnote": "2.1.0",
+        "micromark-extension-gfm-table": "2.1.1",
+        "micromark-extension-math": "3.1.0",
+        "micromark-util-types": "2.0.2",
+        "string-width": "8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/DavidAnson"
+      }
+    },
+    "node_modules/markdownlint-cli": {
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.48.0.tgz",
+      "integrity": "sha512-NkZQNu2E0Q5qLEEHwWj674eYISTLD4jMHkBzDobujXd1kv+yCxi8jOaD/rZoQNW1FBBMMGQpuW5So8B51N/e0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "~14.0.3",
+        "deep-extend": "~0.6.0",
+        "ignore": "~7.0.5",
+        "js-yaml": "~4.1.1",
+        "jsonc-parser": "~3.3.1",
+        "jsonpointer": "~5.0.1",
+        "markdown-it": "~14.1.1",
+        "markdownlint": "~0.40.0",
+        "minimatch": "~10.2.4",
+        "run-con": "~1.3.2",
+        "smol-toml": "~1.6.0",
+        "tinyglobby": "~0.2.15"
+      },
+      "bin": {
+        "markdownlint": "markdownlint.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/run-con": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.2.tgz",
+      "integrity": "sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~4.1.0",
+        "minimist": "^1.2.8",
+        "strip-json-comments": "~3.1.1"
+      },
+      "bin": {
+        "run-con": "cli.js"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "refcheck-docs",
+  "private": true,
+  "description": "Docs QA tooling for refcheck",
+  "devDependencies": {
+    "markdownlint-cli": "0.48.0",
+    "prettier": "3.8.1"
+  }
+}


### PR DESCRIPTION
## Summary

Add a documentation quality assurance pipeline mirroring the pattern used in eva-security-onboarding-system: **Prettier** for Markdown formatting, **markdownlint-cli** for linting, and **refcheck** (dogfooding) for broken reference validation.

## Changes

### New config files
- `package.json` — Prettier 3.8.1 + markdownlint-cli 0.48.0 as devDependencies
- `.prettierrc.yml` — prose wrapping at 100 chars
- `.prettierignore` — excludes test fixtures, Python files, build artifacts
- `.markdownlint.yaml` — lint rules (MD013 off since Prettier handles line length, MD041 off, MD024 siblings_only, allowed HTML elements)
- `.markdownlintignore` — excludes test fixtures, auto-generated CHANGELOG
- `.refcheckignore` — excludes .github/, test fixtures, build artifacts

### Makefile targets (7 new)
- `docs-format` / `docs-format-check` — Prettier write vs check modes
- `docs-lint` / `docs-lint-check` — markdownlint with/without --fix
- `docs-refcheck` — runs refcheck on project docs (dogfooding)
- `docs-qa` — composite auto-fix target
- `docs-qa-check` — composite CI-safe non-modifying target
- Updated `init` target to also run `npm install`

### CI integration
- New `docs-qa` job in `build-validation.yml` running in parallel with test jobs
- Uses Python 3.12 + Node.js 20, runs `make docs-qa-check`

### Formatting fixes
- All existing Markdown files auto-formatted by Prettier to comply
- Test fixtures (`tests/fixtures/**`, `tests/sample_markdown.md`) excluded from all checks

## Verification
- `make docs-qa-check` passes with zero errors
- `make docs-qa` is idempotent (no changes on re-run)
- Test fixture files remain untouched